### PR TITLE
Fix warnings, formatting, and lint

### DIFF
--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -1,8 +1,8 @@
 extern crate skryn;
 extern crate webrender;
 
-use std::sync::{Arc,Mutex};
 use std::any::Any;
+use std::sync::{Arc, Mutex};
 
 //use skryn::data::*;
 use skryn::elements::*;
@@ -20,15 +20,13 @@ enum Operation {
 }
 
 #[derive(Debug, Clone)]
-struct Calculator{
-    ops: Vec<Operation>
+struct Calculator {
+    ops: Vec<Operation>,
 }
 
 impl Calculator {
-    fn new() -> Calculator{
-        Calculator {
-            ops: vec![],
-        }
+    fn new() -> Calculator {
+        Calculator { ops: vec![] }
     }
 
     fn push_num(&mut self, n: f64) {
@@ -44,54 +42,54 @@ impl Calculator {
         }
     }
 
-    fn push_op(&mut self, op: Operation) -> Result<Option<f64>,&str>{
+    fn push_op(&mut self, op: Operation) -> Result<Option<f64>, &str> {
         let ops = self.ops.clone();
         let len = self.ops.len();
         let mut return_value = Ok(None);
         match op {
             Operation::Answer => {
                 if len > 2 {
-                    match (&ops[len - 3],&ops[len - 1]) {
-                        (Operation::Input(l),Operation::Input(r)) => {
+                    match (&ops[len - 3], &ops[len - 1]) {
+                        (Operation::Input(l), Operation::Input(r)) => {
                             match &ops[len - 2] {
                                 Operation::Add => {
                                     self.ops.push(Operation::Answer);
-                                    return_value = Ok(Some(l+r));
-                                },
+                                    return_value = Ok(Some(l + r));
+                                }
                                 Operation::Subtract => {
                                     self.ops.push(Operation::Answer);
-                                    return_value = Ok(Some(l-r));
+                                    return_value = Ok(Some(l - r));
                                     //self.ops.push(Operation::Input(l-r));
-                                },
+                                }
                                 Operation::Multiply => {
                                     self.ops.push(Operation::Answer);
-                                    return_value = Ok(Some(l*r));
+                                    return_value = Ok(Some(l * r));
                                     //self.ops.push(Operation::Input(l*r));
-                                },
+                                }
                                 Operation::Divide => {
                                     self.ops.push(Operation::Answer);
-                                    return_value = Ok(Some(l/r));
+                                    return_value = Ok(Some(l / r));
                                     //self.ops.push(Operation::Input(l/r));
-                                },
-                                _ => ()
+                                }
+                                _ => (),
                             }
-                        },
-                        _ => ()
+                        }
+                        _ => (),
                     }
                 }
-            },
+            }
             Operation::Input(n) => {
                 self.push_num(n);
                 return_value = Ok(Some(n))
             }
             _ => {
-                if let Some(xop)  = ops.last() {
+                if let Some(xop) = ops.last() {
                     match xop {
                         Operation::Input(_) => {
                             self.ops.push(op);
                             return_value = Ok(None)
-                        },
-                        _ => ()
+                        }
+                        _ => (),
                     }
                 }
             }
@@ -102,25 +100,33 @@ impl Calculator {
 }
 
 #[derive(Clone)]
-struct CalculatorView{
+struct CalculatorView {
     calc: Arc<Mutex<Calculator>>,
     view: Arc<Mutex<VBox>>,
     textbox: Arc<Mutex<TextBox>>,
 }
 
-impl CalculatorView{
-    fn new() -> CalculatorView{
+impl CalculatorView {
+    fn new() -> CalculatorView {
         let calc = Arc::new(Mutex::new(Calculator::new()));
         let mut view = VBox::new();
 
         let mut history_scroll = ScrollBox::new();
-        history_scroll.set(skryn::gui::properties::Property::BgColor(ColorF::new(0.95,0.95,0.95,1.0)));
+        history_scroll.set(skryn::gui::properties::Property::BgColor(ColorF::new(
+            0.95, 0.95, 0.95, 1.0,
+        )));
 
         let mut history = TextBox::new("Calculation History\n".to_owned());
-        history.set(skryn::gui::properties::Property::Color(ColorF::new(0.2,0.2,0.2,1.0)));
-        history.set(skryn::gui::properties::Property::Height(skryn::gui::properties::Unit::Natural));
+        history.set(skryn::gui::properties::Property::Color(ColorF::new(
+            0.2, 0.2, 0.2, 1.0,
+        )));
+        history.set(skryn::gui::properties::Property::Height(
+            skryn::gui::properties::Unit::Natural,
+        ));
         history.set(skryn::gui::properties::Property::Size(16));
-        history.set(skryn::gui::properties::Property::TextAlign(skryn::gui::properties::Align::Right));
+        history.set(skryn::gui::properties::Property::TextAlign(
+            skryn::gui::properties::Align::Right,
+        ));
         history.set_editable(false);
         let history = Arc::new(Mutex::new(history));
 
@@ -129,163 +135,237 @@ impl CalculatorView{
 
         let mut tbox = TextBox::new("".to_owned());
         tbox.set_singleline(true);
-        tbox.set(skryn::gui::properties::Property::Height(skryn::gui::properties::Unit::Pixel(40.0)));
+        tbox.set(skryn::gui::properties::Property::Height(
+            skryn::gui::properties::Unit::Pixel(40.0),
+        ));
         tbox.set(skryn::gui::properties::Property::Size(32));
-        tbox.set(skryn::gui::properties::Property::HoverBgColor(ColorF::new(0.75,0.75,0.75,1.0)));
-        tbox.set(skryn::gui::properties::Property::TextAlign(skryn::gui::properties::Align::Right));
+        tbox.set(skryn::gui::properties::Property::HoverBgColor(ColorF::new(
+            0.75, 0.75, 0.75, 1.0,
+        )));
+        tbox.set(skryn::gui::properties::Property::TextAlign(
+            skryn::gui::properties::Align::Right,
+        ));
         let tbox = Arc::new(Mutex::new(tbox));
         view.append(tbox.clone());
 
         let mut hbox = HBox::new();
-        hbox.set(skryn::gui::properties::Property::Height(skryn::gui::properties::Unit::Pixel(44.0)));
+        hbox.set(skryn::gui::properties::Property::Height(
+            skryn::gui::properties::Unit::Pixel(44.0),
+        ));
         let mut addbutt = Button::new("+".to_owned());
         addbutt.set(skryn::gui::properties::Property::Size(32));
-        addbutt.set(skryn::gui::properties::Property::TextAlign(skryn::gui::properties::Align::Middle));
-        addbutt.set(skryn::gui::properties::Property::Top(skryn::gui::properties::Unit::Stretch(1.0)));
-        addbutt.set(skryn::gui::properties::Property::Bottom(skryn::gui::properties::Unit::Stretch(1.0)));
+        addbutt.set(skryn::gui::properties::Property::TextAlign(
+            skryn::gui::properties::Align::Middle,
+        ));
+        addbutt.set(skryn::gui::properties::Property::Top(
+            skryn::gui::properties::Unit::Stretch(1.0),
+        ));
+        addbutt.set(skryn::gui::properties::Property::Bottom(
+            skryn::gui::properties::Unit::Stretch(1.0),
+        ));
         let tmpbox = tbox.clone();
         let tmpcalc = calc.clone();
         let tmphist = history.clone();
-        addbutt.set_handler(skryn::elements::ElementEvent::Clicked,EventFn::new(Arc::new(Mutex::new( move |_e:&mut Element,_d:&Any| {
-            let mut tb = tmpbox.lock().unwrap();
-            let val = tb.get_value().parse::<f64>();
-            if let Ok(n) = val {
-                if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
-                    tmphist.lock().unwrap().append_value(format!("{}\n+\n",n));
-                    tmpcalc.lock().unwrap().push_op(Operation::Add).unwrap();
+        addbutt.set_handler(
+            skryn::elements::ElementEvent::Clicked,
+            EventFn::new(Arc::new(Mutex::new(move |_e: &mut Element, _d: &Any| {
+                let mut tb = tmpbox.lock().unwrap();
+                let val = tb.get_value().parse::<f64>();
+                if let Ok(n) = val {
+                    if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
+                        tmphist.lock().unwrap().append_value(format!("{}\n+\n", n));
+                        tmpcalc.lock().unwrap().push_op(Operation::Add).unwrap();
+                    }
+                    tb.set_value("".to_owned());
+                } else {
+                    Alert::show(
+                        format!("Value {} could not be parsed to a number.", tb.get_value()),
+                        "Number Error".to_owned(),
+                    );
                 }
-                tb.set_value("".to_owned());
-            } else {
-                Alert::show(format!("Value {} could not be parsed to a number.",tb.get_value()), "Number Error".to_owned());
-            }
 
-            true
-        }))));
+                true
+            }))),
+        );
         hbox.append(Arc::new(Mutex::new(addbutt)));
 
         let mut subbutt = Button::new("-".to_owned());
         subbutt.set(skryn::gui::properties::Property::Size(32));
-        subbutt.set(skryn::gui::properties::Property::TextAlign(skryn::gui::properties::Align::Middle));
-        subbutt.set(skryn::gui::properties::Property::Top(skryn::gui::properties::Unit::Stretch(1.0)));
-        subbutt.set(skryn::gui::properties::Property::Bottom(skryn::gui::properties::Unit::Stretch(1.0)));
+        subbutt.set(skryn::gui::properties::Property::TextAlign(
+            skryn::gui::properties::Align::Middle,
+        ));
+        subbutt.set(skryn::gui::properties::Property::Top(
+            skryn::gui::properties::Unit::Stretch(1.0),
+        ));
+        subbutt.set(skryn::gui::properties::Property::Bottom(
+            skryn::gui::properties::Unit::Stretch(1.0),
+        ));
         let tmpbox = tbox.clone();
         let tmpcalc = calc.clone();
         let tmphist = history.clone();
-        subbutt.set_handler(skryn::elements::ElementEvent::Clicked, EventFn::new(Arc::new(Mutex::new( move |_e:&mut Element,_d:&Any| {
-            let mut tb = tmpbox.lock().unwrap();
-            let val = tb.get_value().parse::<f64>();
-            if let Ok(n) = val {
-                if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
-                    tmphist.lock().unwrap().append_value(format!("{}\n-\n",n));
-                    tmpcalc.lock().unwrap().push_op(Operation::Subtract).unwrap();
+        subbutt.set_handler(
+            skryn::elements::ElementEvent::Clicked,
+            EventFn::new(Arc::new(Mutex::new(move |_e: &mut Element, _d: &Any| {
+                let mut tb = tmpbox.lock().unwrap();
+                let val = tb.get_value().parse::<f64>();
+                if let Ok(n) = val {
+                    if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
+                        tmphist.lock().unwrap().append_value(format!("{}\n-\n", n));
+                        tmpcalc
+                            .lock()
+                            .unwrap()
+                            .push_op(Operation::Subtract)
+                            .unwrap();
+                    }
+                    tb.set_value("".to_owned());
+                } else {
+                    Alert::show(
+                        format!("Value {} could not be parsed to a number.", tb.get_value()),
+                        "Number Error".to_owned(),
+                    );
                 }
-                tb.set_value("".to_owned());
-            } else {
-                Alert::show(format!("Value {} could not be parsed to a number.",tb.get_value()), "Number Error".to_owned());
-            }
 
-            true
-        }))));
+                true
+            }))),
+        );
         hbox.append(Arc::new(Mutex::new(subbutt)));
 
         let mut mulbutt = Button::new("*".to_owned());
         mulbutt.set(skryn::gui::properties::Property::Size(32));
-        mulbutt.set(skryn::gui::properties::Property::TextAlign(skryn::gui::properties::Align::Middle));
-        mulbutt.set(skryn::gui::properties::Property::Top(skryn::gui::properties::Unit::Stretch(1.0)));
-        mulbutt.set(skryn::gui::properties::Property::Bottom(skryn::gui::properties::Unit::Stretch(1.0)));
+        mulbutt.set(skryn::gui::properties::Property::TextAlign(
+            skryn::gui::properties::Align::Middle,
+        ));
+        mulbutt.set(skryn::gui::properties::Property::Top(
+            skryn::gui::properties::Unit::Stretch(1.0),
+        ));
+        mulbutt.set(skryn::gui::properties::Property::Bottom(
+            skryn::gui::properties::Unit::Stretch(1.0),
+        ));
         let tmpbox = tbox.clone();
         let tmpcalc = calc.clone();
         let tmphist = history.clone();
-        mulbutt.set_handler(skryn::elements::ElementEvent::Clicked, EventFn::new(Arc::new(Mutex::new( move |_e:&mut Element,_d:&Any| {
-            let mut tb = tmpbox.lock().unwrap();
-            let val = tb.get_value().parse::<f64>();
-            if let Ok(n) = val {
-                if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
-                    tmphist.lock().unwrap().append_value(format!("{}\n*\n",n));
-                    tmpcalc.lock().unwrap().push_op(Operation::Multiply).unwrap();
+        mulbutt.set_handler(
+            skryn::elements::ElementEvent::Clicked,
+            EventFn::new(Arc::new(Mutex::new(move |_e: &mut Element, _d: &Any| {
+                let mut tb = tmpbox.lock().unwrap();
+                let val = tb.get_value().parse::<f64>();
+                if let Ok(n) = val {
+                    if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
+                        tmphist.lock().unwrap().append_value(format!("{}\n*\n", n));
+                        tmpcalc
+                            .lock()
+                            .unwrap()
+                            .push_op(Operation::Multiply)
+                            .unwrap();
+                    }
+                    tb.set_value("".to_owned());
+                } else {
+                    Alert::show(
+                        format!("Value {} could not be parsed to a number.", tb.get_value()),
+                        "Number Error".to_owned(),
+                    );
                 }
-                tb.set_value("".to_owned());
-            } else {
-                Alert::show(format!("Value {} could not be parsed to a number.",tb.get_value()), "Number Error".to_owned());
-            }
 
-            true
-        }))));
+                true
+            }))),
+        );
         hbox.append(Arc::new(Mutex::new(mulbutt)));
 
         let mut divbutt = Button::new("/".to_owned());
         divbutt.set(skryn::gui::properties::Property::Size(32));
-        divbutt.set(skryn::gui::properties::Property::TextAlign(skryn::gui::properties::Align::Middle));
-        divbutt.set(skryn::gui::properties::Property::Top(skryn::gui::properties::Unit::Stretch(1.0)));
-        divbutt.set(skryn::gui::properties::Property::Bottom(skryn::gui::properties::Unit::Stretch(1.0)));
+        divbutt.set(skryn::gui::properties::Property::TextAlign(
+            skryn::gui::properties::Align::Middle,
+        ));
+        divbutt.set(skryn::gui::properties::Property::Top(
+            skryn::gui::properties::Unit::Stretch(1.0),
+        ));
+        divbutt.set(skryn::gui::properties::Property::Bottom(
+            skryn::gui::properties::Unit::Stretch(1.0),
+        ));
         let tmpbox = tbox.clone();
         let tmpcalc = calc.clone();
         let tmphist = history.clone();
-        divbutt.set_handler(skryn::elements::ElementEvent::Clicked, EventFn::new(Arc::new(Mutex::new( move |_e:&mut Element,_d:&Any| {
-            let mut tb = tmpbox.lock().unwrap();
-            let val = tb.get_value().parse::<f64>();
-            if let Ok(n) = val {
-                if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
-                    tmphist.lock().unwrap().append_value(format!("{}\n/\n",n));
-                    tmpcalc.lock().unwrap().push_op(Operation::Divide).unwrap();
+        divbutt.set_handler(
+            skryn::elements::ElementEvent::Clicked,
+            EventFn::new(Arc::new(Mutex::new(move |_e: &mut Element, _d: &Any| {
+                let mut tb = tmpbox.lock().unwrap();
+                let val = tb.get_value().parse::<f64>();
+                if let Ok(n) = val {
+                    if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
+                        tmphist.lock().unwrap().append_value(format!("{}\n/\n", n));
+                        tmpcalc.lock().unwrap().push_op(Operation::Divide).unwrap();
+                    }
+                    tb.set_value("".to_owned());
+                } else {
+                    Alert::show(
+                        format!("Value {} could not be parsed to a number.", tb.get_value()),
+                        "Number Error".to_owned(),
+                    );
                 }
-                tb.set_value("".to_owned());
-            } else {
-                Alert::show(format!("Value {} could not be parsed to a number.",tb.get_value()), "Number Error".to_owned());
-            }
 
-            true
-        }))));
+                true
+            }))),
+        );
         hbox.append(Arc::new(Mutex::new(divbutt)));
 
         let mut eqlbutt = Button::new("=".to_owned());
         eqlbutt.set(skryn::gui::properties::Property::Size(32));
-        eqlbutt.set(skryn::gui::properties::Property::TextAlign(skryn::gui::properties::Align::Middle));
-        eqlbutt.set(skryn::gui::properties::Property::Top(skryn::gui::properties::Unit::Stretch(1.0)));
-        eqlbutt.set(skryn::gui::properties::Property::Bottom(skryn::gui::properties::Unit::Stretch(1.0)));
+        eqlbutt.set(skryn::gui::properties::Property::TextAlign(
+            skryn::gui::properties::Align::Middle,
+        ));
+        eqlbutt.set(skryn::gui::properties::Property::Top(
+            skryn::gui::properties::Unit::Stretch(1.0),
+        ));
+        eqlbutt.set(skryn::gui::properties::Property::Bottom(
+            skryn::gui::properties::Unit::Stretch(1.0),
+        ));
         let tmpbox = tbox.clone();
         let tmpcalc = calc.clone();
         let tmphist = history.clone();
-        eqlbutt.set_handler(skryn::elements::ElementEvent::Clicked, EventFn::new(Arc::new(Mutex::new( move |_e:&mut Element,_d:&Any| {
-            let mut tb = tmpbox.lock().unwrap();
-            let val = tb.get_value().parse::<f64>();
-            if let Ok(n) = val {
-                if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
-                    let v = tmpcalc.lock().unwrap().push_op(Operation::Answer).unwrap();
-                    if let Some(_v) = v {
-                        tmphist.lock().unwrap().append_value(format!("{}\n=\n",n));
-                        tb.set_value(format!("{}", _v));
+        eqlbutt.set_handler(
+            skryn::elements::ElementEvent::Clicked,
+            EventFn::new(Arc::new(Mutex::new(move |_e: &mut Element, _d: &Any| {
+                let mut tb = tmpbox.lock().unwrap();
+                let val = tb.get_value().parse::<f64>();
+                if let Ok(n) = val {
+                    if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
+                        let v = tmpcalc.lock().unwrap().push_op(Operation::Answer).unwrap();
+                        if let Some(_v) = v {
+                            tmphist.lock().unwrap().append_value(format!("{}\n=\n", n));
+                            tb.set_value(format!("{}", _v));
+                        }
                     }
+                } else {
+                    Alert::show(
+                        format!("Value {} could not be parsed to a number.", tb.get_value()),
+                        "Number Error".to_owned(),
+                    );
                 }
-            } else {
-                Alert::show(format!("Value {} could not be parsed to a number.",tb.get_value()), "Number Error".to_owned());
-            }
 
-            true
-        }))));
+                true
+            }))),
+        );
         hbox.append(Arc::new(Mutex::new(eqlbutt)));
 
         view.append(Arc::new(Mutex::new(hbox)));
 
-        CalculatorView{
+        CalculatorView {
             calc: calc,
             view: Arc::new(Mutex::new(view)),
             textbox: tbox,
         }
     }
-
-
 }
 
 struct Alert;
-impl Alert{
-    fn show(message: String, heading: String){
+impl Alert {
+    fn show(message: String, heading: String) {
         let msg_box = TextBox::new(message);
-        skryn::gui::window::Manager::add(Arc::new(Mutex::new(msg_box)),heading,400.0,100.0);
+        skryn::gui::window::Manager::add(Arc::new(Mutex::new(msg_box)), heading, 400.0, 100.0);
     }
 }
 
-fn main(){
+fn main() {
     let calc = CalculatorView::new();
 
     //Calc.push_num(1.0);
@@ -298,9 +378,8 @@ fn main(){
     calc.push_op(Operation::Answer);
     calc.push_op(Operation::Input(1.0)); // should be ignored?*/
 
-
     //println!("{:?}", calc.ops);
 
-    skryn::gui::window::Manager::add(calc.view.clone(),String::from("Calculator"), 300.0, 200.0);
+    skryn::gui::window::Manager::add(calc.view.clone(), String::from("Calculator"), 300.0, 200.0);
     skryn::gui::window::Manager::start(60);
 }

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -3,15 +3,11 @@ extern crate webrender;
 
 use std::sync::{Arc,Mutex};
 use std::any::Any;
-use std::thread;
-use std::time::Duration;
 
 //use skryn::data::*;
-use skryn::gui::font::FontStore;
-use skryn::gui::properties::{Property, Extent, Properties, IdGenerator};
 use skryn::elements::*;
 
-use webrender::api::{ColorF, DisplayListBuilder, RenderApi};
+use webrender::api::ColorF;
 
 #[derive(Debug, Clone)]
 enum Operation {
@@ -156,7 +152,7 @@ impl CalculatorView{
             if let Ok(n) = val {
                 if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
                     tmphist.lock().unwrap().append_value(format!("{}\n+\n",n));
-                    tmpcalc.lock().unwrap().push_op(Operation::Add);
+                    tmpcalc.lock().unwrap().push_op(Operation::Add).unwrap();
                 }
                 tb.set_value("".to_owned());
             } else {
@@ -181,7 +177,7 @@ impl CalculatorView{
             if let Ok(n) = val {
                 if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
                     tmphist.lock().unwrap().append_value(format!("{}\n-\n",n));
-                    tmpcalc.lock().unwrap().push_op(Operation::Subtract);
+                    tmpcalc.lock().unwrap().push_op(Operation::Subtract).unwrap();
                 }
                 tb.set_value("".to_owned());
             } else {
@@ -206,7 +202,7 @@ impl CalculatorView{
             if let Ok(n) = val {
                 if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
                     tmphist.lock().unwrap().append_value(format!("{}\n*\n",n));
-                    tmpcalc.lock().unwrap().push_op(Operation::Multiply);
+                    tmpcalc.lock().unwrap().push_op(Operation::Multiply).unwrap();
                 }
                 tb.set_value("".to_owned());
             } else {
@@ -231,7 +227,7 @@ impl CalculatorView{
             if let Ok(n) = val {
                 if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
                     tmphist.lock().unwrap().append_value(format!("{}\n/\n",n));
-                    tmpcalc.lock().unwrap().push_op(Operation::Divide);
+                    tmpcalc.lock().unwrap().push_op(Operation::Divide).unwrap();
                 }
                 tb.set_value("".to_owned());
             } else {
@@ -290,7 +286,7 @@ impl Alert{
 }
 
 fn main(){
-    let mut calc = CalculatorView::new();
+    let calc = CalculatorView::new();
 
     //Calc.push_num(1.0);
     /*calc.push_op(Operation::Input(1.0));

--- a/examples/calculator.rs
+++ b/examples/calculator.rs
@@ -173,7 +173,7 @@ impl CalculatorView {
                 let val = tb.get_value().parse::<f64>();
                 if let Ok(n) = val {
                     if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
-                        tmphist.lock().unwrap().append_value(format!("{}\n+\n", n));
+                        tmphist.lock().unwrap().append_value(&format!("{}\n+\n", n));
                         tmpcalc.lock().unwrap().push_op(Operation::Add).unwrap();
                     }
                     tb.set_value("".to_owned());
@@ -210,7 +210,7 @@ impl CalculatorView {
                 let val = tb.get_value().parse::<f64>();
                 if let Ok(n) = val {
                     if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
-                        tmphist.lock().unwrap().append_value(format!("{}\n-\n", n));
+                        tmphist.lock().unwrap().append_value(&format!("{}\n-\n", n));
                         tmpcalc
                             .lock()
                             .unwrap()
@@ -251,7 +251,7 @@ impl CalculatorView {
                 let val = tb.get_value().parse::<f64>();
                 if let Ok(n) = val {
                     if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
-                        tmphist.lock().unwrap().append_value(format!("{}\n*\n", n));
+                        tmphist.lock().unwrap().append_value(&format!("{}\n*\n", n));
                         tmpcalc
                             .lock()
                             .unwrap()
@@ -292,7 +292,7 @@ impl CalculatorView {
                 let val = tb.get_value().parse::<f64>();
                 if let Ok(n) = val {
                     if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
-                        tmphist.lock().unwrap().append_value(format!("{}\n/\n", n));
+                        tmphist.lock().unwrap().append_value(&format!("{}\n/\n", n));
                         tmpcalc.lock().unwrap().push_op(Operation::Divide).unwrap();
                     }
                     tb.set_value("".to_owned());
@@ -331,7 +331,7 @@ impl CalculatorView {
                     if tmpcalc.lock().unwrap().push_op(Operation::Input(n)).is_ok() {
                         let v = tmpcalc.lock().unwrap().push_op(Operation::Answer).unwrap();
                         if let Some(_v) = v {
-                            tmphist.lock().unwrap().append_value(format!("{}\n=\n", n));
+                            tmphist.lock().unwrap().append_value(&format!("{}\n=\n", n));
                             tb.set_value(format!("{}", _v));
                         }
                     }

--- a/examples/mainexample.rs
+++ b/examples/mainexample.rs
@@ -1,16 +1,15 @@
-
 extern crate skryn;
 extern crate webrender;
 
-use std::sync::{Arc,Mutex};
 use std::any::Any;
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
 
 use skryn::data::*;
-use skryn::gui::font::FontStore;
-use skryn::gui::properties::{Property, Extent, Properties, IdGenerator};
 use skryn::elements::*;
+use skryn::gui::font::FontStore;
+use skryn::gui::properties::{Extent, IdGenerator, Properties, Property};
 
 use webrender::api::{ColorF, DisplayListBuilder, RenderApi};
 
@@ -22,7 +21,7 @@ use webrender::api::{ColorF, DisplayListBuilder, RenderApi};
     ObservableU32 already exist as types.
 */
 
-struct Person{
+struct Person {
     name: ObservableString,
     age: ObservableU32,
 }
@@ -35,28 +34,28 @@ struct Person{
     not needed.
 */
 
-impl Person{
-    fn new(name:String,age:u32) -> Person {
-        Person{
-            name:ObservableString::new(name),
-            age:ObservableU32::new(age),
+impl Person {
+    fn new(name: String, age: u32) -> Person {
+        Person {
+            name: ObservableString::new(name),
+            age: ObservableU32::new(age),
         }
     }
 
     #[allow(unused)]
-    fn on_name_change(&mut self,listener: Box<FnMut(&String)+Send>) -> u64{
+    fn on_name_change(&mut self, listener: Box<FnMut(&String) + Send>) -> u64 {
         self.name.observe(listener)
     }
 
-    fn on_age_change(&mut self,listener: Box<FnMut(&u32)+Send>) -> u64 {
+    fn on_age_change(&mut self, listener: Box<FnMut(&u32) + Send>) -> u64 {
         self.age.observe(listener)
     }
 
-    fn remove_name_listener(&mut self, id: u64){
+    fn remove_name_listener(&mut self, id: u64) {
         self.name.stop(id);
     }
 
-    fn remove_age_listener(&mut self,id: u64){
+    fn remove_age_listener(&mut self, id: u64) {
         self.age.stop(id);
     }
 }
@@ -67,7 +66,7 @@ impl Person{
     Element to encapsulate the view.
 */
 
-struct PersonElm{
+struct PersonElm {
     //Every element is given an id. This
     //is used in referencing the main bounding
     //box of Elements
@@ -92,26 +91,41 @@ struct PersonElm{
     name_observer_id: Option<u64>,
 }
 
-impl PersonElm{
-    fn new(p:Arc<Mutex<Person>>) -> PersonElm{
+impl PersonElm {
+    fn new(p: Arc<Mutex<Person>>) -> PersonElm {
         //Create two TextBoxes and display their initial value
         let mut _p = p.lock().unwrap();
-        let name = Arc::new(Mutex::new( TextBox::new(_p.name.get_value())));
-        let age= Arc::new(Mutex::new( TextBox::new(String::from(format!("{}",_p.age.get_value())))));
+        let name = Arc::new(Mutex::new(TextBox::new(_p.name.get_value())));
+        let age = Arc::new(Mutex::new(TextBox::new(String::from(format!(
+            "{}",
+            _p.age.get_value()
+        )))));
         //This is an alert button just to show how easy it is to spawn new windows.
         let alert_button = Arc::new(Mutex::new(Button::new(format!("Press here!"))));
         let cancel_button = Arc::new(Mutex::new(Button::new(format!("Cancel"))));
         let h = Arc::new(Mutex::new(HBox::new()));
-        h.lock().unwrap().set(skryn::gui::properties::Property::Left(skryn::gui::properties::Unit::Stretch(1.0)));
-        h.lock().unwrap().set(skryn::gui::properties::Property::Right(skryn::gui::properties::Unit::Stretch(1.0)));
+        h.lock()
+            .unwrap()
+            .set(skryn::gui::properties::Property::Left(
+                skryn::gui::properties::Unit::Stretch(1.0),
+            ));
+        h.lock()
+            .unwrap()
+            .set(skryn::gui::properties::Property::Right(
+                skryn::gui::properties::Unit::Stretch(1.0),
+            ));
         match h.lock() {
             Ok(ref mut h) => {
                 h.append(alert_button.clone());
                 h.append(cancel_button.clone());
-                h.set(skryn::gui::properties::Property::Height(skryn::gui::properties::Unit::Pixel(25.0)));
-                h.set(skryn::gui::properties::Property::BgColor(ColorF::new(0.2,1.0,0.2,1.0)));
-            },
-            Err(_err_str) => panic!("unable to lock element : {}", _err_str)
+                h.set(skryn::gui::properties::Property::Height(
+                    skryn::gui::properties::Unit::Pixel(25.0),
+                ));
+                h.set(skryn::gui::properties::Property::BgColor(ColorF::new(
+                    0.2, 1.0, 0.2, 1.0,
+                )));
+            }
+            Err(_err_str) => panic!("unable to lock element : {}", _err_str),
         }
 
         //skryn has 4 Length Units at the moment.
@@ -120,47 +134,84 @@ impl PersonElm{
         //  -> Extent means the extent (bounding box) of parent element
         //  -> Stretch means use a percentage of the parent's extent (bounding box)
         //  -> Pixel is the static length
-        name.lock().unwrap().set(skryn::gui::properties::Property::Height(skryn::gui::properties::Unit::Stretch(1.0)));
-        age.lock().unwrap().set(skryn::gui::properties::Property::Height(skryn::gui::properties::Unit::Stretch(1.0)));
+        name.lock()
+            .unwrap()
+            .set(skryn::gui::properties::Property::Height(
+                skryn::gui::properties::Unit::Stretch(1.0),
+            ));
+        age.lock()
+            .unwrap()
+            .set(skryn::gui::properties::Property::Height(
+                skryn::gui::properties::Unit::Stretch(1.0),
+            ));
         age.lock().unwrap().set_editable(false);
-        alert_button.lock().unwrap().set(skryn::gui::properties::Property::Width(skryn::gui::properties::Unit::Pixel(75.0)));
-        cancel_button.lock().unwrap().set(skryn::gui::properties::Property::Width(skryn::gui::properties::Unit::Pixel(75.0)));
+        alert_button
+            .lock()
+            .unwrap()
+            .set(skryn::gui::properties::Property::Width(
+                skryn::gui::properties::Unit::Pixel(75.0),
+            ));
+        cancel_button
+            .lock()
+            .unwrap()
+            .set(skryn::gui::properties::Property::Width(
+                skryn::gui::properties::Unit::Pixel(75.0),
+            ));
         //Here we have used the Stretch unit for elements above to make sure our VBox below is utilized to the full.
-        let v = Arc::new(Mutex::new( VBox::new()));
-        v.lock().unwrap().set(skryn::gui::properties::Property::Top(skryn::gui::properties::Unit::Stretch(1.0)));
-        v.lock().unwrap().set(skryn::gui::properties::Property::Bottom(skryn::gui::properties::Unit::Stretch(1.0)));
-        v.lock().unwrap().set(skryn::gui::properties::Property::Left(skryn::gui::properties::Unit::Stretch(0.2)));
-        v.lock().unwrap().set(skryn::gui::properties::Property::Right(skryn::gui::properties::Unit::Stretch(0.2)));
+        let v = Arc::new(Mutex::new(VBox::new()));
+        v.lock().unwrap().set(skryn::gui::properties::Property::Top(
+            skryn::gui::properties::Unit::Stretch(1.0),
+        ));
+        v.lock()
+            .unwrap()
+            .set(skryn::gui::properties::Property::Bottom(
+                skryn::gui::properties::Unit::Stretch(1.0),
+            ));
+        v.lock()
+            .unwrap()
+            .set(skryn::gui::properties::Property::Left(
+                skryn::gui::properties::Unit::Stretch(0.2),
+            ));
+        v.lock()
+            .unwrap()
+            .set(skryn::gui::properties::Property::Right(
+                skryn::gui::properties::Unit::Stretch(0.2),
+            ));
         match v.lock() {
             Ok(ref mut v) => {
                 v.append(name.clone());
                 v.append(age.clone());
                 v.append(h.clone());
-                v.set(skryn::gui::properties::Property::BgColor(ColorF::new(1.0,0.2,0.2,1.0)));
-            },
-            Err(_err_str) => panic!("unable to lock element : {}", _err_str)
+                v.set(skryn::gui::properties::Property::BgColor(ColorF::new(
+                    1.0, 0.2, 0.2, 1.0,
+                )));
+            }
+            Err(_err_str) => panic!("unable to lock element : {}", _err_str),
         }
 
         //The following is a simple action taken when our button is clicked.
         //An alert window is created.
-        alert_button.lock().unwrap().set_handler(ElementEvent::Clicked, EventFn::new(Arc::new(Mutex::new( move |_e:&mut Element,_d:&Any| {
-            Alert::show("This is an Alert Box".to_owned(),"Alert".to_owned());
-            true
-        }))));
+        alert_button.lock().unwrap().set_handler(
+            ElementEvent::Clicked,
+            EventFn::new(Arc::new(Mutex::new(move |_e: &mut Element, _d: &Any| {
+                Alert::show("This is an Alert Box".to_owned(), "Alert".to_owned());
+                true
+            }))),
+        );
 
         // make sure you sae the observer id for age
         // so that we can remove the listener when
         // this Element is no longer required.
-        let age_o_id = _p.on_age_change(Box::new(move |v|{
-            let _ageelm = age.lock().unwrap().set_value(format!("{}",v));
+        let age_o_id = _p.on_age_change(Box::new(move |v| {
+            let _ageelm = age.lock().unwrap().set_value(format!("{}", v));
         }));
 
         //finally return the constructed element
-        PersonElm{
-            id:0,
+        PersonElm {
+            id: 0,
             person: p.clone(),
             vbox: v,
-            bounds: Extent{
+            bounds: Extent {
                 x: 0.0,
                 y: 0.0,
                 w: 0.0,
@@ -178,7 +229,6 @@ impl PersonElm{
     for creating a custom element
 */
 impl Element for PersonElm {
-
     fn get_ext_id(&self) -> u64 {
         self.id
     }
@@ -187,17 +237,25 @@ impl Element for PersonElm {
         self.vbox.lock().unwrap().set(_prop);
     }
 
-    fn get_properties(&self) -> skryn::gui::properties::Properties{
+    fn get_properties(&self) -> skryn::gui::properties::Properties {
         self.vbox.lock().unwrap().get_properties()
     }
 
-    fn render(&mut self, api: &RenderApi, builder: &mut DisplayListBuilder, extent: Extent, font_store: &mut FontStore, _props: Option<Arc<Properties>>, gen: &mut IdGenerator) {
+    fn render(
+        &mut self,
+        api: &RenderApi,
+        builder: &mut DisplayListBuilder,
+        extent: Extent,
+        font_store: &mut FontStore,
+        _props: Option<Arc<Properties>>,
+        gen: &mut IdGenerator,
+    ) {
         match self.vbox.lock() {
             Ok(ref mut elm) => {
-                elm.render(api,builder,extent,font_store,None, gen);
+                elm.render(api, builder, extent, font_store, None, gen);
                 self.bounds = elm.get_bounds();
-            },
-            Err(_err_str) => panic!("unable to lock element : {}",_err_str)
+            }
+            Err(_err_str) => panic!("unable to lock element : {}", _err_str),
         }
     }
 
@@ -219,8 +277,8 @@ impl Element for PersonElm {
         match self.vbox.lock() {
             Ok(ref mut elm) => {
                 return elm.on_primitive_event(ext_ids, e);
-            },
-            Err(_err_str) => panic!("unable to lock element : {}", _err_str)
+            }
+            Err(_err_str) => panic!("unable to lock element : {}", _err_str),
         }
     }
 
@@ -256,15 +314,14 @@ impl Drop for PersonElm {
     an alert message.
 */
 struct Alert;
-impl Alert{
-    fn show(message: String, heading: String){
+impl Alert {
+    fn show(message: String, heading: String) {
         let msg_box = TextBox::new(message);
-        skryn::gui::window::Manager::add(Arc::new(Mutex::new(msg_box)),heading,400.0,100.0);
+        skryn::gui::window::Manager::add(Arc::new(Mutex::new(msg_box)), heading, 400.0, 100.0);
     }
 }
 
-fn main () {
-
+fn main() {
     //create the person.
     let person = Person::new(String::from("<Insert name here>"), 0);
 
@@ -275,10 +332,15 @@ fn main () {
 
     //create an Instance of PersonElm and add it to the window manager.
     let form = PersonElm::new(person);
-    skryn::gui::window::Manager::add(Arc::new(Mutex::new(form)),String::from("Main window"), 300.0, 200.0);
+    skryn::gui::window::Manager::add(
+        Arc::new(Mutex::new(form)),
+        String::from("Main window"),
+        300.0,
+        200.0,
+    );
 
     //spawn a worker thread to update the age
-    thread::spawn(move ||{
+    thread::spawn(move || {
         let mut t = 0;
         loop {
             {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -1,18 +1,17 @@
-
 use std::collections::HashMap;
 
-pub struct Observable<T: Clone>{
+pub struct Observable<T: Clone> {
     next_id: u64,
     value: T,
-    observers: HashMap<u64,Box<FnMut(&T)+Send>>
+    observers: HashMap<u64, Box<FnMut(&T) + Send>>,
 }
 
-impl <T: Clone> Observable <T> {
-    pub fn new(value:T)-> Self{
-        Self{
+impl<T: Clone> Observable<T> {
+    pub fn new(value: T) -> Self {
+        Self {
             next_id: 0,
             value,
-            observers:HashMap::new(),
+            observers: HashMap::new(),
         }
     }
 
@@ -20,42 +19,42 @@ impl <T: Clone> Observable <T> {
         self.value.clone()
     }
 
-    pub fn observe(&mut self, observer: Box<FnMut(&T)+Send>) -> u64 {
-        self.observers.insert(self.next_id,observer);
+    pub fn observe(&mut self, observer: Box<FnMut(&T) + Send>) -> u64 {
+        self.observers.insert(self.next_id, observer);
         let tmp = self.next_id;
         self.next_id += 1;
 
         tmp
     }
 
-    pub fn stop(&mut self, id: u64){
+    pub fn stop(&mut self, id: u64) {
         self.observers.remove(&id);
     }
 
-    fn notify_observers(&mut self){
-        for o in self.observers.values_mut(){
+    fn notify_observers(&mut self) {
+        for o in self.observers.values_mut() {
             o(&self.value);
         }
     }
 }
 
-pub enum Action<T: Clone>{
+pub enum Action<T: Clone> {
     Add(T),
     Remove(T),
     Update(T),
 }
 
 pub trait Update<T: Clone> {
-    fn update(&mut self, value:Action<T>);
+    fn update(&mut self, value: Action<T>);
 }
 
-impl <T: Clone> Update<T> for Observable<T>{
+impl<T: Clone> Update<T> for Observable<T> {
     fn update(&mut self, value: Action<T>) {
         match value {
             Action::Update(v) => {
                 self.value = v;
                 self.notify_observers();
-            },
+            }
             _ => (),
         }
     }

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -50,12 +50,9 @@ pub trait Update<T: Clone> {
 
 impl<T: Clone> Update<T> for Observable<T> {
     fn update(&mut self, value: Action<T>) {
-        match value {
-            Action::Update(v) => {
-                self.value = v;
-                self.notify_observers();
-            }
-            _ => (),
+        if let Action::Update(v) = value {
+            self.value = v;
+            self.notify_observers();
         }
     }
 }

--- a/src/elements/button.rs
+++ b/src/elements/button.rs
@@ -1,14 +1,13 @@
-use std::sync::Arc;
 use std::any::Any;
+use std::sync::Arc;
 
 use webrender::api::*;
 
 use elements::element::*;
-use gui::properties;
 use gui::font;
+use gui::properties;
 
-pub struct Button
-{
+pub struct Button {
     ext_id: u64,
     value: String,
     props: properties::Properties,
@@ -23,9 +22,14 @@ impl Button {
     pub fn new(s: String) -> Self {
         let mut props = properties::Properties::new();
         props.default();
-        props.set(properties::Property::BgColor(ColorF::new(0.8, 0.9, 0.9, 1.0)))
+        props
+            .set(properties::Property::BgColor(ColorF::new(
+                0.8, 0.9, 0.9, 1.0,
+            )))
             .set(properties::Property::Color(ColorF::new(0.2, 0.2, 0.2, 1.0)))
-            .set(properties::Property::HoverBgColor(ColorF::new(0.6, 0.7, 0.7, 1.0)));
+            .set(properties::Property::HoverBgColor(ColorF::new(
+                0.6, 0.7, 0.7, 1.0,
+            )));
         Button {
             ext_id: 0,
             value: s,
@@ -54,60 +58,62 @@ impl Button {
         self.value.clone()
     }
 
-    fn get_width_sums(&mut self) -> (f32,f32) {
+    fn get_width_sums(&mut self) -> (f32, f32) {
         let left = self.props.get_left();
         let right = self.props.get_right();
         let width = self.props.get_width();
 
-        let mut stretchy:f32 = 0.0;
-        let mut pixel:f32 = 0.0;
+        let mut stretchy: f32 = 0.0;
+        let mut pixel: f32 = 0.0;
 
         match left {
             properties::Unit::Stretch(_s) => stretchy += _s,
             properties::Unit::Pixel(_p) => pixel += _p,
-            _ => ()
+            _ => (),
         }
 
         match right {
             properties::Unit::Stretch(_s) => stretchy += _s,
             properties::Unit::Pixel(_p) => pixel += _p,
-            _ => ()
+            _ => (),
         }
 
         match width {
             properties::Unit::Stretch(_s) => stretchy += _s,
             properties::Unit::Pixel(_p) => pixel += _p,
-            _ => ()
+            _ => (),
         }
 
-        (pixel,stretchy)
+        (pixel, stretchy)
     }
 
-    fn get_height_sums(&mut self) -> (f32,f32) {
+    fn get_height_sums(&mut self) -> (f32, f32) {
         let top = self.props.get_top();
         let bottom = self.props.get_bottom();
 
-        let mut stretchy:f32 = 0.0;
-        let mut pixel:f32 = (self.props.get_size() * self.value.lines().count() as i32) as f32;
+        let mut stretchy: f32 = 0.0;
+        let mut pixel: f32 = (self.props.get_size() * self.value.lines().count() as i32) as f32;
 
         match top {
             properties::Unit::Stretch(_s) => stretchy += _s,
             properties::Unit::Pixel(_p) => pixel += _p,
-            _ => ()
+            _ => (),
         }
 
         match bottom {
             properties::Unit::Stretch(_s) => stretchy += _s,
             properties::Unit::Pixel(_p) => pixel += _p,
-            _ => ()
+            _ => (),
         }
 
-        (pixel,stretchy)
+        (pixel, stretchy)
     }
 }
 
 impl Element for Button {
-    fn get_ext_id(&self) -> u64 { self.ext_id }
+    fn get_ext_id(&self) -> u64 {
+        self.ext_id
+    }
 
     fn set(&mut self, prop: properties::Property) {
         self.props.set(prop);
@@ -121,18 +127,17 @@ impl Element for Button {
         self.props.clone()
     }
 
-    fn render(&mut self,
-              _api: &RenderApi,
-              builder: &mut DisplayListBuilder,
-              extent: properties::Extent,
-              font_store: &mut font::FontStore,
-              _props: Option<Arc<properties::Properties>>,
-              gen: &mut properties::IdGenerator) {
-
-
+    fn render(
+        &mut self,
+        _api: &RenderApi,
+        builder: &mut DisplayListBuilder,
+        extent: properties::Extent,
+        font_store: &mut font::FontStore,
+        _props: Option<Arc<properties::Properties>>,
+        gen: &mut properties::IdGenerator,
+    ) {
         let _id = gen.get();
         self.ext_id = _id;
-
 
         let mut color = self.props.get_color();
         let mut bgcolor = self.props.get_bg_color();
@@ -146,23 +151,25 @@ impl Element for Button {
         let bottom = self.props.get_bottom();
         let left = self.props.get_left();
 
-        let (wp_sum, ws_sum )= self.get_width_sums();
+        let (wp_sum, ws_sum) = self.get_width_sums();
         let mut remaining_width = extent.w - wp_sum;
-        if remaining_width < 0.0 {remaining_width = 0.0;}
+        if remaining_width < 0.0 {
+            remaining_width = 0.0;
+        }
         let mut w_stretchy_factor = remaining_width / ws_sum;
         if w_stretchy_factor.is_nan() || w_stretchy_factor.is_infinite() {
             w_stretchy_factor = 0.0;
         }
 
-        let (hp_sum, hs_sum )= self.get_height_sums();
+        let (hp_sum, hs_sum) = self.get_height_sums();
         let mut remaining_height = extent.h - hp_sum;
-        if remaining_height < 0.0 {remaining_height = 0.0;}
+        if remaining_height < 0.0 {
+            remaining_height = 0.0;
+        }
         let mut h_stretchy_factor = remaining_height / hs_sum;
         if h_stretchy_factor.is_nan() || h_stretchy_factor.is_infinite() {
             h_stretchy_factor = 0.0;
         }
-
-
 
         if self.hovering && self.enabled {
             color = self.props.get_hover_color();
@@ -180,47 +187,48 @@ impl Element for Button {
             properties::Unit::Pixel(_p) => {
                 calc_y += _p;
                 calc_h -= _p;
-            },
-            properties::Unit::Stretch(_s) =>{
+            }
+            properties::Unit::Stretch(_s) => {
                 calc_y += _s * h_stretchy_factor;
                 calc_h -= _s * h_stretchy_factor;
-            },
-            _ => ()
+            }
+            _ => (),
         }
 
         match bottom {
             properties::Unit::Pixel(_p) => calc_h -= _p,
             properties::Unit::Stretch(_s) => calc_h -= _s * h_stretchy_factor,
-            _ => ()
+            _ => (),
         }
-
 
         match left {
             properties::Unit::Pixel(_p) => {
                 calc_x += _p;
                 calc_w -= _p;
-            },
+            }
             properties::Unit::Stretch(_s) => {
                 calc_x += _s * w_stretchy_factor;
                 calc_w -= _s * w_stretchy_factor;
-            },
-            _ => ()
+            }
+            _ => (),
         }
         match right {
             properties::Unit::Pixel(_p) => calc_w -= _p,
             properties::Unit::Stretch(_s) => calc_w -= _s * w_stretchy_factor,
-            _ => ()
+            _ => (),
         }
 
-        let (glyphs, tbounds, _) = font::FontRaster::place_lines(&self.value,
-                                                                     calc_x,
-                                                                     calc_y,
-                                                                     calc_w,
-                                                                     calc_h,
-                                                                     size,
-                                                                     &family,
-                                                                     text_align,
-                                                                     font_store);
+        let (glyphs, tbounds, _) = font::FontRaster::place_lines(
+            &self.value,
+            calc_x,
+            calc_y,
+            calc_w,
+            calc_h,
+            size,
+            &family,
+            text_align,
+            font_store,
+        );
 
         let mut calc_w = tbounds.w;
         let mut calc_h = tbounds.h;
@@ -238,7 +246,6 @@ impl Element for Button {
             properties::Unit::Stretch(s) => s * extent.h,
             properties::Unit::Natural => calc_h,
         };
-
 
         self.bounds = properties::Extent {
             x: extent.x,
@@ -260,11 +267,13 @@ impl Element for Button {
             LayoutSize::new(tbounds.w, tbounds.h),
         ));
 
-        builder.push_text(&info,
-                          &glyphs,
-                          fi_key.clone(),
-                          color.clone(),
-                          Some(GlyphOptions::default()));
+        builder.push_text(
+            &info,
+            &glyphs,
+            fi_key.clone(),
+            color.clone(),
+            Some(GlyphOptions::default()),
+        );
     }
 
     fn get_bounds(&self) -> properties::Extent {
@@ -281,28 +290,24 @@ impl Element for Button {
                     if b == properties::Button::Left
                         && s == properties::ButtonState::Released
                         && self.enabled
-                        {
-                            handled = self.exec_handler(ElementEvent::Clicked, &m);
-                        }
+                    {
+                        handled = self.exec_handler(ElementEvent::Clicked, &m);
+                    }
                 }
-            },
+            }
             PrimitiveEvent::HoverBegin(n_tags) => {
-                let matched = n_tags.iter().find(|x|{
-                    x.0 == self.ext_id
-                });
-                if let Some(_) =  matched {
+                let matched = n_tags.iter().find(|x| x.0 == self.ext_id);
+                if let Some(_) = matched {
                     self.hovering = true;
                 }
-            },
+            }
             PrimitiveEvent::HoverEnd(o_tags) => {
-                let matched = o_tags.iter().find(|x|{
-                    x.0 == self.ext_id
-                });
-                if let Some(_) =  matched {
+                let matched = o_tags.iter().find(|x| x.0 == self.ext_id);
+                if let Some(_) = matched {
                     self.hovering = false;
                 }
-            },
-            _ => ()
+            }
+            _ => (),
         }
 
         return handled;
@@ -314,7 +319,7 @@ impl Element for Button {
 
     fn exec_handler(&mut self, _e: ElementEvent, _d: &Any) -> bool {
         let h = self.event_handlers.get_mut(&_e).cloned();
-        if let Some(mut h) = h{
+        if let Some(mut h) = h {
             h.call(self, _d)
         } else {
             false

--- a/src/elements/button.rs
+++ b/src/elements/button.rs
@@ -226,7 +226,7 @@ impl Element for Button {
             calc_h,
             size,
             &family,
-            text_align,
+            &text_align,
             font_store,
         );
 
@@ -267,13 +267,7 @@ impl Element for Button {
             LayoutSize::new(tbounds.w, tbounds.h),
         ));
 
-        builder.push_text(
-            &info,
-            &glyphs,
-            fi_key.clone(),
-            color.clone(),
-            Some(GlyphOptions::default()),
-        );
+        builder.push_text(&info, &glyphs, fi_key, color, Some(GlyphOptions::default()));
     }
 
     fn get_bounds(&self) -> properties::Extent {
@@ -286,31 +280,31 @@ impl Element for Button {
         match e {
             PrimitiveEvent::Button(_p, b, s, m) => {
                 self.drawn = 0;
-                if ext_ids.len() == 1 && ext_ids[0].0 == self.ext_id {
-                    if b == properties::Button::Left
-                        && s == properties::ButtonState::Released
-                        && self.enabled
-                    {
-                        handled = self.exec_handler(ElementEvent::Clicked, &m);
-                    }
+                if ext_ids.len() == 1
+                    && ext_ids[0].0 == self.ext_id
+                    && b == properties::Button::Left
+                    && s == properties::ButtonState::Released
+                    && self.enabled
+                {
+                    handled = self.exec_handler(ElementEvent::Clicked, &m);
                 }
             }
             PrimitiveEvent::HoverBegin(n_tags) => {
                 let matched = n_tags.iter().find(|x| x.0 == self.ext_id);
-                if let Some(_) = matched {
+                if matched.is_some() {
                     self.hovering = true;
                 }
             }
             PrimitiveEvent::HoverEnd(o_tags) => {
                 let matched = o_tags.iter().find(|x| x.0 == self.ext_id);
-                if let Some(_) = matched {
+                if matched.is_some() {
                     self.hovering = false;
                 }
             }
             _ => (),
         }
 
-        return handled;
+        handled
     }
 
     fn set_handler(&mut self, _e: ElementEvent, _f: EventFn) {

--- a/src/elements/element.rs
+++ b/src/elements/element.rs
@@ -38,7 +38,7 @@ pub enum PrimitiveEvent {
     HoverEnd(Vec<ItemTag>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq)]
 pub enum ElementEvent {
     Clicked,
     FocusChange,
@@ -52,13 +52,21 @@ impl Hash for ElementEvent {
     }
 }
 
+impl PartialEq for ElementEvent {
+    fn eq(&self, other: &ElementEvent) -> bool {
+        mem::discriminant(self) == mem::discriminant(other)
+    }
+}
+
 /*impl Copy for FnMut(&mut Element, &Any) -> bool {
 
 }*/
 
 //pub type EventFn = fn(&mut Element, &Any) -> bool;
+pub type EventClosure = FnMut(&mut Element, &Any) -> bool;
+
 #[derive(Clone)]
-pub struct EventFn(Arc<Mutex<FnMut(&mut Element, &Any) -> bool>>);
+pub struct EventFn(Arc<Mutex<EventClosure>>);
 //it should be safe since Element will always be within a lock.
 //sending it as arc.mutex.element might end up in a deadlock
 unsafe impl Send for EventFn {}
@@ -66,7 +74,7 @@ unsafe impl Sync for EventFn {}
 
 use std::ops::DerefMut;
 impl EventFn {
-    pub fn new(f: Arc<Mutex<FnMut(&mut Element, &Any) -> bool>>) -> EventFn {
+    pub fn new(f: Arc<Mutex<EventClosure>>) -> EventFn {
         EventFn(f)
     }
 

--- a/src/elements/hbox.rs
+++ b/src/elements/hbox.rs
@@ -102,6 +102,12 @@ impl HBox {
     }
 }
 
+impl Default for HBox {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Element for HBox {
     fn get_ext_id(&self) -> u64 {
         self.ext_id
@@ -303,14 +309,11 @@ impl Element for HBox {
         // if none of the children handled the event
         // see if you can handle it here
         if !handled {
-            match e {
-                PrimitiveEvent::Button(_p, _b, _s, m) => {
-                    handled = self.exec_handler(ElementEvent::Clicked, &m);
-                }
-                _ => (),
+            if let PrimitiveEvent::Button(_p, _b, _s, m) = e {
+                handled = self.exec_handler(ElementEvent::Clicked, &m);
             }
         }
-        return handled;
+        handled
     }
 
     fn set_handler(&mut self, _e: ElementEvent, _f: EventFn) {

--- a/src/elements/hbox.rs
+++ b/src/elements/hbox.rs
@@ -1,30 +1,30 @@
-use std::sync::{Arc,Mutex};
 use std::any::Any;
+use std::sync::{Arc, Mutex};
 
 use webrender::api::*;
 
-use util::*;
 use elements::element::*;
-use gui::properties;
 use gui::font;
+use gui::properties;
+use util::*;
 
 pub struct HBox {
-    ext_id:u64,
+    ext_id: u64,
     children: Vec<Arc<Mutex<Element>>>,
     props: properties::Properties,
     bounds: properties::Extent,
     handlers: EventHandlers,
 }
 
-impl HBox  {
-    pub fn new() -> Self{
+impl HBox {
+    pub fn new() -> Self {
         let mut props = properties::Properties::new();
         props.default();
         HBox {
-            ext_id:0,
-            children:Vec::new(),
+            ext_id: 0,
+            children: Vec::new(),
             props,
-            bounds: properties::Extent{
+            bounds: properties::Extent {
                 x: 0.0,
                 y: 0.0,
                 w: 0.0,
@@ -35,23 +35,23 @@ impl HBox  {
         }
     }
 
-    fn get_width_sums(&mut self) -> (f32,f32) {
+    fn get_width_sums(&mut self) -> (f32, f32) {
         let left = self.props.get_left();
         let right = self.props.get_right();
 
-        let mut stretchy:f32 = 0.0;
-        let mut pixel:f32 = 0.0;
+        let mut stretchy: f32 = 0.0;
+        let mut pixel: f32 = 0.0;
 
         match left {
             properties::Unit::Stretch(_s) => stretchy += _s,
             properties::Unit::Pixel(_p) => pixel += _p,
-            _ => ()
+            _ => (),
         }
 
         match right {
             properties::Unit::Stretch(_s) => stretchy += _s,
             properties::Unit::Pixel(_p) => pixel += _p,
-            _ => ()
+            _ => (),
         }
 
         for elm in self.children.iter() {
@@ -64,46 +64,48 @@ impl HBox  {
                         if !_p.is_nan() && !_p.is_infinite() {
                             pixel += _p;
                         }
-                    },
+                    }
                 }
             }
         }
 
-        (pixel,stretchy)
+        (pixel, stretchy)
     }
 
-    fn get_height_sums(&mut self) -> (f32,f32) {
+    fn get_height_sums(&mut self) -> (f32, f32) {
         let top = self.props.get_top();
         let bottom = self.props.get_bottom();
         let height = self.props.get_height();
 
-        let mut stretchy:f32 = 0.0;
-        let mut pixel:f32 = 0.0;
+        let mut stretchy: f32 = 0.0;
+        let mut pixel: f32 = 0.0;
 
         match top {
             properties::Unit::Stretch(_s) => stretchy += _s,
             properties::Unit::Pixel(_p) => pixel += _p,
-            _ => ()
+            _ => (),
         }
 
         match bottom {
             properties::Unit::Stretch(_s) => stretchy += _s,
             properties::Unit::Pixel(_p) => pixel += _p,
-            _ => ()
+            _ => (),
         }
 
         match height {
             properties::Unit::Stretch(_s) => stretchy += _s,
             properties::Unit::Pixel(_p) => pixel += _p,
-            _ => ()
+            _ => (),
         }
 
-        (pixel,stretchy)
+        (pixel, stretchy)
     }
 }
 
-impl  Element for HBox {
-    fn get_ext_id(&self)->u64{self.ext_id}
+impl Element for HBox {
+    fn get_ext_id(&self) -> u64 {
+        self.ext_id
+    }
 
     fn set(&mut self, prop: properties::Property) {
         self.props.set(prop);
@@ -117,14 +119,15 @@ impl  Element for HBox {
         self.props.clone()
     }
 
-    fn render(&mut self,
-              api: &RenderApi,
-              builder: &mut DisplayListBuilder,
-              extent: properties::Extent,
-              font_store: &mut font::FontStore,
-              _props: Option<Arc<properties::Properties>>,
-              gen: &mut properties::IdGenerator) {
-
+    fn render(
+        &mut self,
+        api: &RenderApi,
+        builder: &mut DisplayListBuilder,
+        extent: properties::Extent,
+        font_store: &mut font::FontStore,
+        _props: Option<Arc<properties::Properties>>,
+        gen: &mut properties::IdGenerator,
+    ) {
         let bgcolor = self.props.get_bg_color();
         let top = self.props.get_top();
         let bottom = self.props.get_bottom();
@@ -133,29 +136,35 @@ impl  Element for HBox {
         let width = self.props.get_width();
         let height = self.props.get_height();
 
-        let (hp_sum, hs_sum )= self.get_height_sums();
+        let (hp_sum, hs_sum) = self.get_height_sums();
         let mut remaining_height = extent.h - hp_sum;
-        if remaining_height < 0.0 {remaining_height = 0.0;}
+        if remaining_height < 0.0 {
+            remaining_height = 0.0;
+        }
         let mut h_stretchy_factor = remaining_height / hs_sum;
         if h_stretchy_factor.is_nan() {
             h_stretchy_factor = 0.0;
         }
 
-        let (wp_sum, ws_sum )= self.get_width_sums();
+        let (wp_sum, ws_sum) = self.get_width_sums();
         let mut remaining_width = extent.w - wp_sum;
-        if remaining_width < 0.0 {remaining_width = 0.0;}
+        if remaining_width < 0.0 {
+            remaining_width = 0.0;
+        }
         let mut w_stretchy_factor = remaining_width / ws_sum;
         if w_stretchy_factor.is_nan() {
             w_stretchy_factor = 0.0;
         }
 
-//        let mut remaining_width = extent.w;
-//        let mut w_stretchy_factor = extent.w;
+        //        let mut remaining_width = extent.w;
+        //        let mut w_stretchy_factor = extent.w;
 
         let _id = gen.get();
         self.ext_id = _id;
 
-        let mut info = LayoutPrimitiveInfo::new((self.bounds.x, self.bounds.y).by(self.bounds.w, self.bounds.h));
+        let mut info = LayoutPrimitiveInfo::new(
+            (self.bounds.x, self.bounds.y).by(self.bounds.w, self.bounds.h),
+        );
         info.tag = Some((_id, 0));
         builder.push_rect(&info, bgcolor);
 
@@ -177,17 +186,17 @@ impl  Element for HBox {
         match width {
             properties::Unit::Stretch(_s) => remaining_width = _s * w_stretchy_factor,
             properties::Unit::Pixel(_p) => remaining_width = _p,
-            _ => ()
+            _ => (),
         }
 
         match height {
             properties::Unit::Stretch(_s) => remaining_height = _s * h_stretchy_factor,
             properties::Unit::Pixel(_p) => remaining_height = _p,
-            _ => ()
+            _ => (),
         }
 
-        for elm in self.children.iter_mut(){
-            let mut child_extent = properties::Extent{
+        for elm in self.children.iter_mut() {
+            let mut child_extent = properties::Extent {
                 x: next_x + extent.x,
                 y: next_y + extent.y,
                 w: remaining_width,
@@ -202,32 +211,32 @@ impl  Element for HBox {
                     match e_width {
                         properties::Unit::Pixel(_p) => {
                             child_extent.w = _p;
-                        },
+                        }
                         properties::Unit::Stretch(_s) => {
                             child_extent.w = w_stretchy_factor;
-                        },
-                        _ => ()
+                        }
+                        _ => (),
                     }
 
-                    elm.render(api,builder,child_extent,font_store,None,gen);
+                    elm.render(api, builder, child_extent, font_store, None, gen);
                     let _ex = elm.get_bounds();
                     next_x += _ex.w;
-                },
-                Err(_err_str) => panic!("unable to lock element : {}",_err_str)
+                }
+                Err(_err_str) => panic!("unable to lock element : {}", _err_str),
             }
         }
 
         match right {
-            properties::Unit::Stretch(_s) => next_x += _s*w_stretchy_factor,
+            properties::Unit::Stretch(_s) => next_x += _s * w_stretchy_factor,
             properties::Unit::Pixel(_p) => next_x += _p,
-            _ => ()
+            _ => (),
         }
 
         next_y += remaining_height;
         match bottom {
-            properties::Unit::Stretch(_s) => next_y += _s*h_stretchy_factor,
+            properties::Unit::Stretch(_s) => next_y += _s * h_stretchy_factor,
             properties::Unit::Pixel(_p) => next_y += _p,
-            _ => ()
+            _ => (),
         }
 
         // TODO: Remove
@@ -236,7 +245,7 @@ impl  Element for HBox {
             next_x = extent.w;
         }
 
-        self.bounds = properties::Extent{
+        self.bounds = properties::Extent {
             x: extent.x,
             y: extent.y,
             w: next_x,
@@ -249,32 +258,34 @@ impl  Element for HBox {
         self.bounds.clone()
     }
 
-    fn on_primitive_event(&mut self, ext_ids:&[ItemTag], e: PrimitiveEvent) -> bool {
+    fn on_primitive_event(&mut self, ext_ids: &[ItemTag], e: PrimitiveEvent) -> bool {
         let mut handled = false;
         for _child_elm in self.children.iter_mut() {
-            match (&e,_child_elm.lock()) {
+            match (&e, _child_elm.lock()) {
                 (PrimitiveEvent::SetFocus(_), Ok(ref mut _child_elm)) => {
                     if ext_ids.len() > 1
                         && ext_ids[0].0 == self.ext_id
-                        && ext_ids[1].0 == _child_elm.get_ext_id() {
-                        _child_elm.on_primitive_event(&ext_ids[1..], PrimitiveEvent::SetFocus(true));
+                        && ext_ids[1].0 == _child_elm.get_ext_id()
+                    {
+                        _child_elm
+                            .on_primitive_event(&ext_ids[1..], PrimitiveEvent::SetFocus(true));
                     } else {
                         _child_elm.on_primitive_event(&[], PrimitiveEvent::SetFocus(false));
                     }
-                },
+                }
                 (PrimitiveEvent::Char(_c), Ok(ref mut _child_elm)) => {
-                    handled = _child_elm.on_primitive_event(&[],e.clone());
+                    handled = _child_elm.on_primitive_event(&[], e.clone());
                     if handled {
                         break;
                     }
-                },
-                (PrimitiveEvent::HoverBegin(_), Ok(ref mut _child_elm)) =>  {
-                    _child_elm.on_primitive_event(&[],e.clone());
-                },
-                (PrimitiveEvent::HoverEnd(_), Ok(ref mut _child_elm)) =>  {
-                    _child_elm.on_primitive_event(&[],e.clone());
-                },
-                (_, Ok(ref mut _child_elm)) =>  {
+                }
+                (PrimitiveEvent::HoverBegin(_), Ok(ref mut _child_elm)) => {
+                    _child_elm.on_primitive_event(&[], e.clone());
+                }
+                (PrimitiveEvent::HoverEnd(_), Ok(ref mut _child_elm)) => {
+                    _child_elm.on_primitive_event(&[], e.clone());
+                }
+                (_, Ok(ref mut _child_elm)) => {
                     if !handled {
                         if ext_ids.len() == 1 {
                             handled = _child_elm.on_primitive_event(&[], e.clone());
@@ -282,8 +293,8 @@ impl  Element for HBox {
                             handled = _child_elm.on_primitive_event(&ext_ids[1..], e.clone());
                         }
                     }
-                },
-                (_,Err(_err_str)) => {
+                }
+                (_, Err(_err_str)) => {
                     //this should be unreachable
                     panic!("unable to lock element : {}", _err_str)
                 }
@@ -293,44 +304,45 @@ impl  Element for HBox {
         // see if you can handle it here
         if !handled {
             match e {
-                PrimitiveEvent::Button(_p,_b,_s,m) => {
+                PrimitiveEvent::Button(_p, _b, _s, m) => {
                     handled = self.exec_handler(ElementEvent::Clicked, &m);
-                },
-                _ => ()
+                }
+                _ => (),
             }
         }
         return handled;
     }
 
-    fn set_handler(&mut self, _e: ElementEvent, _f:EventFn) {
+    fn set_handler(&mut self, _e: ElementEvent, _f: EventFn) {
         self.handlers.insert(_e, _f);
     }
 
     fn exec_handler(&mut self, _e: ElementEvent, _d: &Any) -> bool {
         let h = self.handlers.get_mut(&_e).cloned();
-        if let Some(mut h) = h{
-            h.call(self,_d)
+        if let Some(mut h) = h {
+            h.call(self, _d)
         } else {
             false
         }
     }
 
-    fn as_any(&self) -> &Any{
+    fn as_any(&self) -> &Any {
         self
     }
-    fn as_any_mut(&mut self) -> &mut Any{
+    fn as_any_mut(&mut self) -> &mut Any {
         self
     }
 }
 
-impl HasChildren for HBox  {
+impl HasChildren for HBox {
     #[allow(unused)]
-    fn get_child(&self, i:u32) -> Option<Arc<Mutex<Element>>> {None}
+    fn get_child(&self, i: u32) -> Option<Arc<Mutex<Element>>> {
+        None
+    }
     #[allow(unused)]
     //fn get_child_mut(&mut self, i:u32) -> Option<&mut Element> {None}
-    fn append(&mut self, e:Arc<Mutex<Element>>) -> Option<Arc<Mutex<Element>>>{
+    fn append(&mut self, e: Arc<Mutex<Element>>) -> Option<Arc<Mutex<Element>>> {
         self.children.push(e);
         None
     }
-
 }

--- a/src/elements/image.rs
+++ b/src/elements/image.rs
@@ -1,4 +1,3 @@
-use std::io;
 use std::io::prelude::*;
 use std::fs::File;
 

--- a/src/elements/image.rs
+++ b/src/elements/image.rs
@@ -1,14 +1,14 @@
-use std::io::prelude::*;
 use std::fs::File;
+use std::io::prelude::*;
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum ImagePath{
+pub enum ImagePath {
     Local(String),
     URL(String),
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Image{
+pub struct Image {
     path: ImagePath,
     bytes: Vec<u8>,
     ext_id: u64,
@@ -21,16 +21,16 @@ impl Image {
             let mut f = File::open(&_s[0..]);
             if let Ok(mut c) = f {
                 let l = c.metadata().unwrap().len();
-                let mut bytes :Vec<u8> = Vec::new();
+                let mut bytes: Vec<u8> = Vec::new();
                 bytes.resize(l as usize, 0);
                 let _r = c.read(&mut bytes);
                 println!("read file ? {:?}", _r);
                 if let Ok(_) = _r {
                     //let bytes = contents.to_vec();
-                    ret = Some(Image{
+                    ret = Some(Image {
                         path,
                         bytes,
-                        ext_id:0,
+                        ext_id: 0,
                     });
                 }
             }

--- a/src/elements/image.rs
+++ b/src/elements/image.rs
@@ -16,18 +16,17 @@ pub struct Image {
 
 impl Image {
     pub fn load(path: ImagePath) -> Option<Image> {
-        let mut ret = None;
         if let ImagePath::Local(_s) = path.clone() {
             let mut f = File::open(&_s[0..]);
             if let Ok(mut c) = f {
                 let l = c.metadata().unwrap().len();
                 let mut bytes: Vec<u8> = Vec::new();
                 bytes.resize(l as usize, 0);
-                let _r = c.read(&mut bytes);
-                println!("read file ? {:?}", _r);
-                if let Ok(_) = _r {
+                let r = c.read(&mut bytes);
+                println!("read file ? {:?}", r);
+                if r.is_ok() {
                     //let bytes = contents.to_vec();
-                    ret = Some(Image {
+                    return Some(Image {
                         path,
                         bytes,
                         ext_id: 0,
@@ -36,6 +35,6 @@ impl Image {
             }
         }
 
-        ret
+        None
     }
 }

--- a/src/elements/mod.rs
+++ b/src/elements/mod.rs
@@ -1,15 +1,15 @@
+mod button;
 mod element;
+mod hbox;
+mod image;
+mod scrollbox;
 mod textbox;
 mod vbox;
-mod hbox;
-mod scrollbox;
-mod button;
-mod image;
 
+pub use self::button::Button;
 pub use self::element::*;
+pub use self::hbox::HBox;
+pub use self::image::*;
+pub use self::scrollbox::ScrollBox;
 pub use self::textbox::TextBox;
 pub use self::vbox::VBox;
-pub use self::hbox::HBox;
-pub use self::scrollbox::ScrollBox;
-pub use self::button::Button;
-pub use self::image::*;

--- a/src/elements/scrollbox.rs
+++ b/src/elements/scrollbox.rs
@@ -145,6 +145,13 @@ impl Element for ScrollBox {
                 (PrimitiveEvent::Char(_c), Ok(ref mut _child_elm)) => {
                     handled = _child_elm.on_primitive_event(&[],e.clone());
                 },
+                // XXX: These used to be unreachable; they trigger a panic in the WRRenderBackend thread
+                // (PrimitiveEvent::HoverBegin(_n_tags), Ok(ref mut _child_elm)) => {
+                //     _child_elm.on_primitive_event(&[],e.clone());
+                // },
+                // (PrimitiveEvent::HoverEnd(_o_tags), Ok(ref mut _child_elm)) => {
+                //     _child_elm.on_primitive_event(&[],e.clone());
+                // },
                 (_, Ok(ref mut _child_elm)) =>  {
                     if !handled {
                         if ext_ids.len() == 1 {
@@ -153,12 +160,6 @@ impl Element for ScrollBox {
                             handled = _child_elm.on_primitive_event(&ext_ids[1..], e.clone());
                         }
                     }
-                },
-                (PrimitiveEvent::HoverBegin(n_tags), Ok(ref mut _child_elm)) => {
-                    _child_elm.on_primitive_event(&[],e.clone());
-                },
-                (PrimitiveEvent::HoverEnd(o_tags), Ok(ref mut _child_elm)) => {
-                    _child_elm.on_primitive_event(&[],e.clone());
                 },
                 (_,Err(_err_str)) => {
                     //this should be unreachable

--- a/src/elements/scrollbox.rs
+++ b/src/elements/scrollbox.rs
@@ -79,7 +79,7 @@ impl Element for ScrollBox {
             None,
             TransformStyle::Flat,
             MixBlendMode::Normal,
-            &vec![],
+            &[],
             RasterSpace::Screen,
         );
 
@@ -87,7 +87,7 @@ impl Element for ScrollBox {
         info.tag = Some((_id, 0));
         builder.push_rect(&info, bgcolor);
 
-        let pipeline_id = builder.pipeline_id.clone();
+        let pipeline_id = builder.pipeline_id;
         let scroll_frame = builder.define_scroll_frame(
             Some(ExternalScrollId(_id, pipeline_id)),
             (0.0, 0.0).by(self.content.w, self.content.h),
@@ -186,14 +186,11 @@ impl Element for ScrollBox {
         // if none of the children handled the event
         // see if you can handle it here
         if !handled {
-            match e {
-                PrimitiveEvent::Button(_p, _b, _s, m) => {
-                    handled = self.exec_handler(ElementEvent::Clicked, &m);
-                }
-                _ => (),
+            if let PrimitiveEvent::Button(_p, _b, _s, m) = e {
+                handled = self.exec_handler(ElementEvent::Clicked, &m);
             }
         }
-        return handled;
+        handled
     }
 
     fn set_handler(&mut self, _e: ElementEvent, _f: EventFn) {
@@ -217,6 +214,12 @@ impl Element for ScrollBox {
     }
 }
 
+impl Default for ScrollBox {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl HasChildren for ScrollBox {
     #[allow(unused)]
     fn get_child(&self, i: u32) -> Option<Arc<Mutex<Element>>> {
@@ -227,6 +230,6 @@ impl HasChildren for ScrollBox {
     fn append(&mut self, e: Arc<Mutex<Element>>) -> Option<Arc<Mutex<Element>>> {
         let mut ret = Some(e);
         mem::swap(&mut self.child, &mut ret);
-        return ret;
+        ret
     }
 }

--- a/src/elements/scrollbox.rs
+++ b/src/elements/scrollbox.rs
@@ -1,13 +1,13 @@
-use std::sync::{Arc,Mutex};
 use std::any::Any;
 use std::mem;
+use std::sync::{Arc, Mutex};
 
 use webrender::api::*;
 
-use util::*;
 use elements::element::*;
-use gui::properties;
 use gui::font;
+use gui::properties;
+use util::*;
 
 pub struct ScrollBox {
     ext_id: u64,
@@ -19,21 +19,21 @@ pub struct ScrollBox {
 }
 
 impl ScrollBox {
-    pub fn new() -> Self{
+    pub fn new() -> Self {
         let mut props = properties::Properties::new();
         props.default();
         ScrollBox {
-            ext_id:0,
+            ext_id: 0,
             child: None,
             props,
-            bounds: properties::Extent{
+            bounds: properties::Extent {
                 x: 0.0,
                 y: 0.0,
                 w: 0.0,
                 h: 0.0,
                 dpi: 0.0,
             },
-            content: properties::Extent{
+            content: properties::Extent {
                 x: 0.0,
                 y: 0.0,
                 w: 0.0,
@@ -46,32 +46,33 @@ impl ScrollBox {
 }
 
 impl Element for ScrollBox {
-    fn get_ext_id(&self)->u64{self.ext_id}
+    fn get_ext_id(&self) -> u64 {
+        self.ext_id
+    }
 
-    fn render(&mut self,
-              api: &RenderApi,
-              builder: &mut DisplayListBuilder,
-              extent: properties::Extent,
-              font_store: &mut font::FontStore,
-              _props: Option<Arc<properties::Properties>>,
-              gen: &mut properties::IdGenerator) {
-
+    fn render(
+        &mut self,
+        api: &RenderApi,
+        builder: &mut DisplayListBuilder,
+        extent: properties::Extent,
+        font_store: &mut font::FontStore,
+        _props: Option<Arc<properties::Properties>>,
+        gen: &mut properties::IdGenerator,
+    ) {
         let bgcolor = self.props.get_bg_color();
 
         let _id = gen.get();
         self.ext_id = _id;
 
-        let mut bounds = properties::Extent{
-            x:  0.0,
-            y:  0.0,
-            w:  0.0,
-            h:  0.0,
-            dpi:0.0
+        let mut bounds = properties::Extent {
+            x: 0.0,
+            y: 0.0,
+            w: 0.0,
+            h: 0.0,
+            dpi: 0.0,
         };
 
         self.bounds = extent.clone();
-
-
 
         builder.push_stacking_context(
             &LayoutPrimitiveInfo::new((extent.x, extent.y).by(0.0, 0.0)),
@@ -82,28 +83,41 @@ impl Element for ScrollBox {
             RasterSpace::Screen,
         );
 
-        let mut info = LayoutPrimitiveInfo::new((0.0,0.0).by(extent.w, extent.h));
+        let mut info = LayoutPrimitiveInfo::new((0.0, 0.0).by(extent.w, extent.h));
         info.tag = Some((_id, 0));
         builder.push_rect(&info, bgcolor);
 
         let pipeline_id = builder.pipeline_id.clone();
-        let scroll_frame = builder.define_scroll_frame(Some(ExternalScrollId(_id,pipeline_id)),
-                                    (0.0,0.0).by(self.content.w, self.content.h),
-                                    (0.0,0.0).by(extent.w,extent.h),
-                                    vec![],
-                                    None,
-                                    ScrollSensitivity::ScriptAndInputEvents);
+        let scroll_frame = builder.define_scroll_frame(
+            Some(ExternalScrollId(_id, pipeline_id)),
+            (0.0, 0.0).by(self.content.w, self.content.h),
+            (0.0, 0.0).by(extent.w, extent.h),
+            vec![],
+            None,
+            ScrollSensitivity::ScriptAndInputEvents,
+        );
         builder.push_clip_id(scroll_frame);
-
-
 
         if let Some(ref mut elm) = self.child {
             match elm.lock() {
                 Ok(ref mut elm) => {
-                    elm.render(api, builder,properties::Extent{x:0.0,y:0.0,w:extent.w,h:extent.h,dpi:extent.dpi},font_store,None,gen);
+                    elm.render(
+                        api,
+                        builder,
+                        properties::Extent {
+                            x: 0.0,
+                            y: 0.0,
+                            w: extent.w,
+                            h: extent.h,
+                            dpi: extent.dpi,
+                        },
+                        font_store,
+                        None,
+                        gen,
+                    );
                     bounds = elm.get_bounds();
-                },
-                Err(_err_str) => panic!("unable to lock element : {}",_err_str)
+                }
+                Err(_err_str) => panic!("unable to lock element : {}", _err_str),
             }
         }
 
@@ -129,19 +143,21 @@ impl Element for ScrollBox {
         self.bounds.clone()
     }
 
-    fn on_primitive_event(&mut self, ext_ids:&[ItemTag], e: PrimitiveEvent) -> bool {
+    fn on_primitive_event(&mut self, ext_ids: &[ItemTag], e: PrimitiveEvent) -> bool {
         let mut handled = false;
-        if let Some (ref mut _child_elm) = self.child {
-            match (&e,_child_elm.lock()) {
+        if let Some(ref mut _child_elm) = self.child {
+            match (&e, _child_elm.lock()) {
                 (PrimitiveEvent::SetFocus(_), Ok(ref mut _child_elm)) => {
                     if ext_ids.len() > 1
                         && ext_ids[0].0 == self.ext_id
-                        && ext_ids[1].0 == _child_elm.get_ext_id() {
-                        _child_elm.on_primitive_event(&ext_ids[1..], PrimitiveEvent::SetFocus(true));
+                        && ext_ids[1].0 == _child_elm.get_ext_id()
+                    {
+                        _child_elm
+                            .on_primitive_event(&ext_ids[1..], PrimitiveEvent::SetFocus(true));
                     } else {
                         _child_elm.on_primitive_event(&[], PrimitiveEvent::SetFocus(false));
                     }
-                },
+                }
                 (PrimitiveEvent::Char(_c), Ok(ref mut _child_elm)) => {
                     handled = _child_elm.on_primitive_event(&[],e.clone());
                 },
@@ -160,8 +176,8 @@ impl Element for ScrollBox {
                             handled = _child_elm.on_primitive_event(&ext_ids[1..], e.clone());
                         }
                     }
-                },
-                (_,Err(_err_str)) => {
+                }
+                (_, Err(_err_str)) => {
                     //this should be unreachable
                     panic!("unable to lock element : {}", _err_str)
                 }
@@ -171,45 +187,46 @@ impl Element for ScrollBox {
         // see if you can handle it here
         if !handled {
             match e {
-                PrimitiveEvent::Button(_p,_b,_s,m) => {
+                PrimitiveEvent::Button(_p, _b, _s, m) => {
                     handled = self.exec_handler(ElementEvent::Clicked, &m);
-                },
-                _ => ()
+                }
+                _ => (),
             }
         }
         return handled;
     }
 
-    fn set_handler(&mut self, _e: ElementEvent, _f:EventFn) {
+    fn set_handler(&mut self, _e: ElementEvent, _f: EventFn) {
         self.handlers.insert(_e, _f);
     }
 
     fn exec_handler(&mut self, _e: ElementEvent, _d: &Any) -> bool {
         let h = self.handlers.get_mut(&_e).cloned();
-        if let Some(mut h) = h{
-            h.call(self,_d)
+        if let Some(mut h) = h {
+            h.call(self, _d)
         } else {
             false
         }
     }
 
-    fn as_any(&self) -> &Any{
+    fn as_any(&self) -> &Any {
         self
     }
-    fn as_any_mut(&mut self) -> &mut Any{
+    fn as_any_mut(&mut self) -> &mut Any {
         self
     }
 }
 
 impl HasChildren for ScrollBox {
     #[allow(unused)]
-    fn get_child(&self, i:u32) -> Option<Arc<Mutex<Element>>> {None}
+    fn get_child(&self, i: u32) -> Option<Arc<Mutex<Element>>> {
+        None
+    }
     #[allow(unused)]
     //fn get_child_mut(&mut self, i:u32) -> Option<&mut Element> {None}
-    fn append(&mut self, e:Arc<Mutex<Element>>) -> Option<Arc<Mutex<Element>>> {
+    fn append(&mut self, e: Arc<Mutex<Element>>) -> Option<Arc<Mutex<Element>>> {
         let mut ret = Some(e);
-        mem::swap(&mut self.child,&mut ret);
+        mem::swap(&mut self.child, &mut ret);
         return ret;
     }
-
 }

--- a/src/elements/textbox.rs
+++ b/src/elements/textbox.rs
@@ -1,7 +1,5 @@
 use std::sync::Arc;
 use std::any::Any;
-use std::collections::HashSet;
-use std::iter::FromIterator;
 
 use glutin::VirtualKeyCode;
 use webrender::api::*;
@@ -182,7 +180,7 @@ impl Element for TextBox {
             bgcolor = self.props.get_disabled_bg_color();
         }
 
-        let (f_key, fi_key) = font_store.get_font_instance(&family, size as i32);
+        let (_f_key, fi_key) = font_store.get_font_instance(&family, size as i32);
 
 
 
@@ -508,4 +506,3 @@ impl CanDisable for TextBox {
         self.enabled
     }
 }
-

--- a/src/elements/textbox.rs
+++ b/src/elements/textbox.rs
@@ -1,13 +1,13 @@
-use std::sync::Arc;
 use std::any::Any;
+use std::sync::Arc;
 
+use clipboard::{ClipboardContext, ClipboardProvider};
 use glutin::VirtualKeyCode;
 use webrender::api::*;
-use clipboard::{ClipboardProvider, ClipboardContext};
 
 use elements::element::*;
-use gui::properties;
 use gui::font;
+use gui::properties;
 
 pub struct TextBox {
     ext_id: u64,
@@ -129,7 +129,9 @@ impl TextBox {
 }
 
 impl Element for TextBox {
-    fn get_ext_id(&self) -> u64 { self.ext_id }
+    fn get_ext_id(&self) -> u64 {
+        self.ext_id
+    }
 
     fn set(&mut self, prop: properties::Property) {
         self.props.set(prop);
@@ -143,13 +145,15 @@ impl Element for TextBox {
         self.props.clone()
     }
 
-    fn render(&mut self,
-              _api: &RenderApi,
-              builder: &mut DisplayListBuilder,
-              extent: properties::Extent,
-              font_store: &mut font::FontStore,
-              _props: Option<Arc<properties::Properties>>,
-              gen: &mut properties::IdGenerator) {
+    fn render(
+        &mut self,
+        _api: &RenderApi,
+        builder: &mut DisplayListBuilder,
+        extent: properties::Extent,
+        font_store: &mut font::FontStore,
+        _props: Option<Arc<properties::Properties>>,
+        gen: &mut properties::IdGenerator,
+    ) {
         let _id = gen.get();
         self.ext_id = _id;
 
@@ -181,8 +185,6 @@ impl Element for TextBox {
         }
 
         let (_f_key, fi_key) = font_store.get_font_instance(&family, size as i32);
-
-
 
         /*let mut next_x = extent.x;
         let mut next_y = extent.y + size;
@@ -263,17 +265,23 @@ impl Element for TextBox {
 
         let val_str = "●".repeat(self.value.len());
 
-        let value = if !self.is_password { &self.value} else {&val_str};
+        let value = if !self.is_password {
+            &self.value
+        } else {
+            &val_str
+        };
 
-        let (mut glyphs, _bounds, cache)= font::FontRaster::place_lines(value,
-                                                       extent.x,
-                                                       extent.y,
-                                                       extent.w,
-                                                       extent.h,
-                                                       size,
-                                                       &family,
-                                                       text_align.clone(),
-                                                       font_store);
+        let (mut glyphs, _bounds, cache) = font::FontRaster::place_lines(
+            value,
+            extent.x,
+            extent.y,
+            extent.w,
+            extent.h,
+            size,
+            &family,
+            text_align.clone(),
+            font_store,
+        );
 
         self.cache = cache;
 
@@ -284,24 +292,24 @@ impl Element for TextBox {
             cursor_x = (self.cache[0].0).0;
             cursor_y = (self.cache[0].1).1;
         } else if self.cache.len() > 0 {
-            cursor_x = (self.cache[cursor_i-1].1).0;
-            cursor_y = (self.cache[cursor_i-1].1).1;
+            cursor_x = (self.cache[cursor_i - 1].1).0;
+            cursor_y = (self.cache[cursor_i - 1].1).1;
         }
 
-        glyphs.retain(|x|{
-            x.index != 0
-        });
+        glyphs.retain(|x| x.index != 0);
 
         if self.value.is_empty() && !self.placeholder.is_empty() && !self.focus {
-            let placeholder = font::FontRaster::place_lines(&self.placeholder,
-                                                             extent.x,
-                                                             extent.y,
-                                                             extent.w,
-                                                             extent.h,
-                                                             size,
-                                                             &family,
-                                                             text_align,
-                                                             font_store);
+            let placeholder = font::FontRaster::place_lines(
+                &self.placeholder,
+                extent.x,
+                extent.y,
+                extent.w,
+                extent.h,
+                size,
+                &family,
+                text_align,
+                font_store,
+            );
 
             let info = LayoutPrimitiveInfo::new(LayoutRect::new(
                 LayoutPoint::new(placeholder.1.x, placeholder.1.y),
@@ -312,11 +320,13 @@ impl Element for TextBox {
                 color = self.props.get_disabled_color();
             }
 
-            builder.push_text(&info,
-                              &placeholder.0,
-                              fi_key.clone(),
-                              color.clone(),
-                              Some(GlyphOptions::default()));
+            builder.push_text(
+                &info,
+                &placeholder.0,
+                fi_key.clone(),
+                color.clone(),
+                Some(GlyphOptions::default()),
+            );
         }
 
         let mut calc_w = _bounds.w;
@@ -355,11 +365,13 @@ impl Element for TextBox {
             LayoutPoint::new(extent.x, extent.y),
             LayoutSize::new(self.bounds.w, self.bounds.h),
         ));
-        builder.push_text(&info,
-                          &glyphs,
-                          fi_key.clone(),
-                          color.clone(),
-                          Some(GlyphOptions::default()));
+        builder.push_text(
+            &info,
+            &glyphs,
+            fi_key.clone(),
+            color.clone(),
+            Some(GlyphOptions::default()),
+        );
 
         //add the cursor
         if self.focus && self.enabled && self.editable {
@@ -387,7 +399,8 @@ impl Element for TextBox {
                             while !self.value.is_char_boundary(l) && l > 0 {
                                 l = l - 1;
                             }
-                            self.value = format!("{}{}", &self.value[0..l], &self.value[self.cursor..]);
+                            self.value =
+                                format!("{}{}", &self.value[0..l], &self.value[self.cursor..]);
                             self.cursor = l;
                         }
                     } else if c == '\u{3}' {
@@ -398,7 +411,12 @@ impl Element for TextBox {
                     } else if c == '\u{16}' {
                         let mut ctx: ClipboardContext = ClipboardProvider::new().unwrap();
                         let vstr = ctx.get_contents().unwrap();
-                        self.value = format!("{}{}{}", &self.value[0..self.cursor], &vstr[0..], &self.value[self.cursor..]);
+                        self.value = format!(
+                            "{}{}{}",
+                            &self.value[0..self.cursor],
+                            &vstr[0..],
+                            &self.value[self.cursor..]
+                        );
                         self.cursor += vstr.len();
                     } else {
                         if c == '\r' {
@@ -412,7 +430,12 @@ impl Element for TextBox {
                                 newstr.push_str(&self.value[0..]);
                                 self.value = newstr;
                             } else if self.cursor < self.value.len() {
-                                self.value = format!("{}{}{}", &self.value[0..self.cursor], c, &self.value[self.cursor..]);
+                                self.value = format!(
+                                    "{}{}{}",
+                                    &self.value[0..self.cursor],
+                                    c,
+                                    &self.value[self.cursor..]
+                                );
                                 ;
                             } else {
                                 self.value.push(c);
@@ -424,13 +447,14 @@ impl Element for TextBox {
                 }
             }
             PrimitiveEvent::Button(_p, b, s, m) => {
-                if ext_ids.len() > 0 && ext_ids[0].0 == self.ext_id
+                if ext_ids.len() > 0
+                    && ext_ids[0].0 == self.ext_id
                     && b == properties::Button::Left
                     && s == properties::ButtonState::Released
-                    {
-                        self.cursor = self.get_index_at(_p.clone());
-                        handled = self.exec_handler(ElementEvent::Clicked, &m);
-                    }
+                {
+                    self.cursor = self.get_index_at(_p.clone());
+                    handled = self.exec_handler(ElementEvent::Clicked, &m);
+                }
             }
             PrimitiveEvent::SetFocus(f) => {
                 if self.enabled {
@@ -440,38 +464,32 @@ impl Element for TextBox {
                     }
                 }
             }
-            PrimitiveEvent::KeyInput(vkc, _sc, s, _m) => {
-                match vkc {
-                    Some(VirtualKeyCode::Right) => {
-                        if self.cursor < self.value.len() && s == properties::ButtonState::Pressed {
-                            self.cursor += 1;
-                        }
+            PrimitiveEvent::KeyInput(vkc, _sc, s, _m) => match vkc {
+                Some(VirtualKeyCode::Right) => {
+                    if self.cursor < self.value.len() && s == properties::ButtonState::Pressed {
+                        self.cursor += 1;
                     }
-                    Some(VirtualKeyCode::Left) => {
-                        if self.cursor > 0 && s == properties::ButtonState::Pressed {
-                            self.cursor -= 1;
-                        }
-                    }
-                    _ => ()
                 }
-            }
+                Some(VirtualKeyCode::Left) => {
+                    if self.cursor > 0 && s == properties::ButtonState::Pressed {
+                        self.cursor -= 1;
+                    }
+                }
+                _ => (),
+            },
             PrimitiveEvent::HoverBegin(n_tags) => {
-                let matched = n_tags.iter().find(|x| {
-                    x.0 == self.ext_id
-                });
+                let matched = n_tags.iter().find(|x| x.0 == self.ext_id);
                 if let Some(_) = matched {
                     self.hovering = true;
                 }
             }
             PrimitiveEvent::HoverEnd(o_tags) => {
-                let matched = o_tags.iter().find(|x| {
-                    x.0 == self.ext_id
-                });
+                let matched = o_tags.iter().find(|x| x.0 == self.ext_id);
                 if let Some(_) = matched {
                     self.hovering = false;
                 }
             }
-            _ => ()
+            _ => (),
         }
         return handled;
     }

--- a/src/elements/vbox.rs
+++ b/src/elements/vbox.rs
@@ -1,12 +1,12 @@
-use std::sync::{Arc,Mutex};
 use std::any::Any;
+use std::sync::{Arc, Mutex};
 
 use webrender::api::*;
 
-use util::*;
 use elements::element::*;
-use gui::properties;
 use gui::font;
+use gui::properties;
+use util::*;
 
 pub struct VBox {
     ext_id: u64,
@@ -17,14 +17,14 @@ pub struct VBox {
 }
 
 impl VBox {
-    pub fn new() -> Self{
+    pub fn new() -> Self {
         let mut props = properties::Properties::new();
         props.default();
         VBox {
-            ext_id:0,
-            children:Vec::new(),
+            ext_id: 0,
+            children: Vec::new(),
             props,
-            bounds: properties::Extent{
+            bounds: properties::Extent {
                 x: 0.0,
                 y: 0.0,
                 w: 0.0,
@@ -35,23 +35,23 @@ impl VBox {
         }
     }
 
-    fn get_height_sums(&mut self) -> (f32,f32) {
+    fn get_height_sums(&mut self) -> (f32, f32) {
         let top = self.props.get_top();
         let bottom = self.props.get_bottom();
 
-        let mut stretchy:f32 = 0.0;
-        let mut pixel:f32 = 0.0;
+        let mut stretchy: f32 = 0.0;
+        let mut pixel: f32 = 0.0;
 
         match top {
             properties::Unit::Stretch(_s) => stretchy += _s,
             properties::Unit::Pixel(_p) => pixel += _p,
-            _ => ()
+            _ => (),
         }
 
         match bottom {
             properties::Unit::Stretch(_s) => stretchy += _s,
             properties::Unit::Pixel(_p) => pixel += _p,
-            _ => ()
+            _ => (),
         }
 
         for elm in self.children.iter() {
@@ -64,46 +64,48 @@ impl VBox {
                         if !_p.is_nan() && !_p.is_infinite() {
                             pixel += _p;
                         }
-                    },
+                    }
                 }
             }
         }
 
-        (pixel,stretchy)
+        (pixel, stretchy)
     }
 
-    fn get_width_sums(&mut self) -> (f32,f32) {
+    fn get_width_sums(&mut self) -> (f32, f32) {
         let left = self.props.get_left();
         let right = self.props.get_right();
         let width = self.props.get_width();
 
-        let mut stretchy:f32 = 0.0;
-        let mut pixel:f32 = 0.0;
+        let mut stretchy: f32 = 0.0;
+        let mut pixel: f32 = 0.0;
 
         match left {
             properties::Unit::Stretch(_s) => stretchy += _s,
             properties::Unit::Pixel(_p) => pixel += _p,
-            _ => ()
+            _ => (),
         }
 
         match right {
             properties::Unit::Stretch(_s) => stretchy += _s,
             properties::Unit::Pixel(_p) => pixel += _p,
-            _ => ()
+            _ => (),
         }
 
         match width {
             properties::Unit::Stretch(_s) => stretchy += _s,
             properties::Unit::Pixel(_p) => pixel += _p,
-            _ => ()
+            _ => (),
         }
 
-        (pixel,stretchy)
+        (pixel, stretchy)
     }
 }
 
 impl Element for VBox {
-    fn get_ext_id(&self)->u64{self.ext_id}
+    fn get_ext_id(&self) -> u64 {
+        self.ext_id
+    }
 
     fn set(&mut self, prop: properties::Property) {
         self.props.set(prop);
@@ -117,14 +119,15 @@ impl Element for VBox {
         self.props.clone()
     }
 
-    fn render(&mut self,
-              api: &RenderApi,
-              builder: &mut DisplayListBuilder,
-              extent: properties::Extent,
-              font_store: &mut font::FontStore,
-              _props: Option<Arc<properties::Properties>>,
-              gen: &mut properties::IdGenerator) {
-
+    fn render(
+        &mut self,
+        api: &RenderApi,
+        builder: &mut DisplayListBuilder,
+        extent: properties::Extent,
+        font_store: &mut font::FontStore,
+        _props: Option<Arc<properties::Properties>>,
+        gen: &mut properties::IdGenerator,
+    ) {
         let bgcolor = self.props.get_bg_color();
         let top = self.props.get_top();
         let bottom = self.props.get_bottom();
@@ -133,27 +136,32 @@ impl Element for VBox {
         let width = self.props.get_width();
         let height = self.props.get_height();
 
-        let (wp_sum, ws_sum )= self.get_width_sums();
+        let (wp_sum, ws_sum) = self.get_width_sums();
         let mut remaining_width = extent.w - wp_sum;
-        if remaining_width < 0.0 {remaining_width = 0.0;}
+        if remaining_width < 0.0 {
+            remaining_width = 0.0;
+        }
         let mut w_stretchy_factor = remaining_width / ws_sum;
         if w_stretchy_factor.is_nan() {
             w_stretchy_factor = 0.0;
         }
 
-        let (hp_sum, hs_sum )= self.get_height_sums();
+        let (hp_sum, hs_sum) = self.get_height_sums();
         let mut remaining_height = extent.h - hp_sum;
-        if remaining_height < 0.0 {remaining_height = 0.0;}
+        if remaining_height < 0.0 {
+            remaining_height = 0.0;
+        }
         let mut h_stretchy_factor = remaining_height / hs_sum;
         if h_stretchy_factor.is_nan() {
             h_stretchy_factor = 0.0;
         }
 
-
         let _id = gen.get();
         self.ext_id = _id;
 
-        let mut info = LayoutPrimitiveInfo::new((self.bounds.x, self.bounds.y).by(self.bounds.w, self.bounds.h));
+        let mut info = LayoutPrimitiveInfo::new(
+            (self.bounds.x, self.bounds.y).by(self.bounds.w, self.bounds.h),
+        );
         info.tag = Some((_id, 0));
         builder.push_rect(&info, bgcolor);
 
@@ -175,17 +183,17 @@ impl Element for VBox {
         match height {
             properties::Unit::Stretch(_s) => remaining_height = _s * h_stretchy_factor,
             properties::Unit::Pixel(_p) => remaining_height = _p,
-            _ => ()
+            _ => (),
         }
 
         match width {
             properties::Unit::Stretch(_s) => remaining_width = _s * w_stretchy_factor,
             properties::Unit::Pixel(_p) => remaining_width = _p,
-            _ => ()
+            _ => (),
         }
 
-        for elm in self.children.iter_mut(){
-            let mut child_extent = properties::Extent{
+        for elm in self.children.iter_mut() {
+            let mut child_extent = properties::Extent {
                 x: next_x + extent.x,
                 y: next_y + extent.y,
                 w: remaining_width,
@@ -200,18 +208,18 @@ impl Element for VBox {
                     match e_height {
                         properties::Unit::Pixel(_p) => {
                             child_extent.h = _p;
-                        },
+                        }
                         properties::Unit::Stretch(_s) => {
                             child_extent.h = h_stretchy_factor;
-                        },
-                        _ => ()
+                        }
+                        _ => (),
                     }
 
                     elm.render(api, builder, child_extent, font_store, None, gen);
                     let _ex = elm.get_bounds();
                     next_y += _ex.h;
-                },
-                Err(_err_str) => panic!("unable to lock element : {}",_err_str)
+                }
+                Err(_err_str) => panic!("unable to lock element : {}", _err_str),
             }
         }
 
@@ -223,7 +231,7 @@ impl Element for VBox {
 
         next_x += remaining_width;
         match right {
-            properties::Unit::Stretch(_s) => next_x +=  w_stretchy_factor * _s,
+            properties::Unit::Stretch(_s) => next_x += w_stretchy_factor * _s,
             properties::Unit::Pixel(_p) => next_x += _p,
             _ => (),
         }
@@ -237,7 +245,7 @@ impl Element for VBox {
             next_x = extent.w;
         }*/
 
-        self.bounds = properties::Extent{
+        self.bounds = properties::Extent {
             x: extent.x,
             y: extent.y,
             w: next_x,
@@ -250,32 +258,34 @@ impl Element for VBox {
         self.bounds.clone()
     }
 
-    fn on_primitive_event(&mut self, ext_ids:&[ItemTag], e: PrimitiveEvent) -> bool {
+    fn on_primitive_event(&mut self, ext_ids: &[ItemTag], e: PrimitiveEvent) -> bool {
         let mut handled = false;
         for _child_elm in self.children.iter_mut() {
-            match (&e,_child_elm.lock()) {
+            match (&e, _child_elm.lock()) {
                 (PrimitiveEvent::SetFocus(_), Ok(ref mut _child_elm)) => {
                     if ext_ids.len() > 1
                         && ext_ids[0].0 == self.ext_id
-                        && ext_ids[1].0 == _child_elm.get_ext_id() {
-                        _child_elm.on_primitive_event(&ext_ids[1..], PrimitiveEvent::SetFocus(true));
+                        && ext_ids[1].0 == _child_elm.get_ext_id()
+                    {
+                        _child_elm
+                            .on_primitive_event(&ext_ids[1..], PrimitiveEvent::SetFocus(true));
                     } else {
                         _child_elm.on_primitive_event(&[], PrimitiveEvent::SetFocus(false));
                     }
-                },
+                }
                 (PrimitiveEvent::Char(_c), Ok(ref mut _child_elm)) => {
-                    handled = _child_elm.on_primitive_event(&[],e.clone());
+                    handled = _child_elm.on_primitive_event(&[], e.clone());
                     if handled {
                         break;
                     }
-                },
-                (PrimitiveEvent::HoverBegin(_), Ok(ref mut _child_elm)) =>  {
-                    _child_elm.on_primitive_event(&[],e.clone());
-                },
-                (PrimitiveEvent::HoverEnd(_), Ok(ref mut _child_elm)) =>  {
-                    _child_elm.on_primitive_event(&[],e.clone());
-                },
-                (_, Ok(ref mut _child_elm)) =>  {
+                }
+                (PrimitiveEvent::HoverBegin(_), Ok(ref mut _child_elm)) => {
+                    _child_elm.on_primitive_event(&[], e.clone());
+                }
+                (PrimitiveEvent::HoverEnd(_), Ok(ref mut _child_elm)) => {
+                    _child_elm.on_primitive_event(&[], e.clone());
+                }
+                (_, Ok(ref mut _child_elm)) => {
                     if !handled {
                         if ext_ids.len() == 1 {
                             handled = _child_elm.on_primitive_event(&[], e.clone());
@@ -283,8 +293,8 @@ impl Element for VBox {
                             handled = _child_elm.on_primitive_event(&ext_ids[1..], e.clone());
                         }
                     }
-                },
-                (_,Err(_err_str)) => {
+                }
+                (_, Err(_err_str)) => {
                     //this should be unreachable
                     panic!("unable to lock element : {}", _err_str)
                 }
@@ -294,44 +304,45 @@ impl Element for VBox {
         // see if you can handle it here
         if !handled {
             match e {
-                PrimitiveEvent::Button(_p,_b,_s,m) => {
+                PrimitiveEvent::Button(_p, _b, _s, m) => {
                     handled = self.exec_handler(ElementEvent::Clicked, &m);
-                },
-                _ => ()
+                }
+                _ => (),
             }
         }
         return handled;
     }
 
-    fn set_handler(&mut self, _e: ElementEvent, _f:EventFn) {
+    fn set_handler(&mut self, _e: ElementEvent, _f: EventFn) {
         self.handlers.insert(_e, _f);
     }
 
     fn exec_handler(&mut self, _e: ElementEvent, _d: &Any) -> bool {
         let h = self.handlers.get_mut(&_e).cloned();
-        if let Some(mut h) = h{
+        if let Some(mut h) = h {
             h.call(self, _d)
         } else {
             false
         }
     }
 
-    fn as_any(&self) -> &Any{
+    fn as_any(&self) -> &Any {
         self
     }
-    fn as_any_mut(&mut self) -> &mut Any{
+    fn as_any_mut(&mut self) -> &mut Any {
         self
     }
 }
 
 impl HasChildren for VBox {
     #[allow(unused)]
-    fn get_child(&self, i:u32) -> Option<Arc<Mutex<Element>>> {None}
+    fn get_child(&self, i: u32) -> Option<Arc<Mutex<Element>>> {
+        None
+    }
     #[allow(unused)]
     //fn get_child_mut(&mut self, i:u32) -> Option<&mut Element> {None}
-    fn append(&mut self, e:Arc<Mutex<Element>>) -> Option<Arc<Mutex<Element>>>{
+    fn append(&mut self, e: Arc<Mutex<Element>>) -> Option<Arc<Mutex<Element>>> {
         self.children.push(e);
         None
     }
-
 }

--- a/src/elements/vbox.rs
+++ b/src/elements/vbox.rs
@@ -102,6 +102,12 @@ impl VBox {
     }
 }
 
+impl Default for VBox {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Element for VBox {
     fn get_ext_id(&self) -> u64 {
         self.ext_id
@@ -303,14 +309,11 @@ impl Element for VBox {
         // if none of the children handled the event
         // see if you can handle it here
         if !handled {
-            match e {
-                PrimitiveEvent::Button(_p, _b, _s, m) => {
-                    handled = self.exec_handler(ElementEvent::Clicked, &m);
-                }
-                _ => (),
+            if let PrimitiveEvent::Button(_p, _b, _s, m) = e {
+                handled = self.exec_handler(ElementEvent::Clicked, &m);
             }
         }
-        return handled;
+        handled
     }
 
     fn set_handler(&mut self, _e: ElementEvent, _f: EventFn) {

--- a/src/gui/font.rs
+++ b/src/gui/font.rs
@@ -2,7 +2,6 @@ use app_units;
 use font_kit;
 use font_kit::{source::SystemSource, font::Font, family_name::FamilyName};
 use std::collections::{HashMap, HashSet};
-use std::iter::FromIterator;
 use webrender::api::*;
 use gui::properties::*;
 
@@ -184,7 +183,6 @@ impl FontRaster {
 
         let mut line_glyphs = vec![];
         let mut max_len = 0.0;
-        let mut max_y = y;
 
         let linefeed_at_end = if value.len() > 0{
             let tmp : Vec<char> = value.chars().collect();
@@ -199,13 +197,12 @@ impl FontRaster {
             if max_len < w {
                 max_len = w;
             }
-            max_y += h;
             line_glyphs.push((t_g, w, h));
             total_lines += 1;
         }
 
         let mut glyphs = vec![];
-        let mut bounds;
+        let bounds;
         let mut dims = vec![];
 
         let mut line_index = 0;
@@ -213,7 +210,7 @@ impl FontRaster {
         match text_align {
             Align::Left => {
                 let (mut _x,mut _y) = (x,y);
-                for (l_g, w, h) in line_glyphs {
+                for (l_g, _w, _h) in line_glyphs {
 
                     if line_index > 0 && line_index<total_lines {
                         dims.push(((_x, _y), (_x , _y + size)));
@@ -243,7 +240,7 @@ impl FontRaster {
             Align::Right => {
                 let mut _y = y;
                 let mut _x = x + _width;
-                for (l_g, w, h) in line_glyphs {
+                for (l_g, w, _h) in line_glyphs {
                     _x = x + _width - w;
 
                     if line_index > 0 && line_index<total_lines {
@@ -276,7 +273,7 @@ impl FontRaster {
             Align::Middle => {
                 let mut _y = y;
                 let mut _x = x + _width;
-                for (l_g, w, h) in line_glyphs {
+                for (l_g, w, _h) in line_glyphs {
                     _x = x + (_width - w)/2.0;
 
                     if line_index > 0 && line_index<total_lines {
@@ -324,7 +321,7 @@ impl FontRaster {
         let (indices, dimens) = font_store.get_glyphs_for_slice(f_key,fi_key, value);
 
         let mut next_x = 0.0;
-        let baseline = (units * metrics.ascent);
+        let baseline = units * metrics.ascent;
 
         let mut glyphs = vec![];
 
@@ -404,4 +401,3 @@ impl FontRaster {
         (glyphs, max_x, next_y)
     }*/
 }
-

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -1,3 +1,3 @@
-pub mod properties;
 pub mod font;
+pub mod properties;
 pub mod window;

--- a/src/gui/properties.rs
+++ b/src/gui/properties.rs
@@ -1,38 +1,38 @@
-use std::collections::{HashSet};
+use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::mem;
-use std::sync::{Mutex, Arc};
+use std::sync::{Arc, Mutex};
 
 use webrender::api::ColorF;
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Point{
-    pub x:f32,
-    pub y:f32,
+pub struct Point {
+    pub x: f32,
+    pub y: f32,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Extent{
-    pub x:f32,
-    pub y:f32,
-    pub w:f32,
-    pub h:f32,
-    pub dpi:f32,
+pub struct Extent {
+    pub x: f32,
+    pub y: f32,
+    pub w: f32,
+    pub h: f32,
+    pub dpi: f32,
 }
 
 #[derive(Clone, Debug)]
-pub enum Unit{
+pub enum Unit {
     Natural,
     Extent,
     Pixel(f32),
     Stretch(f32),
 }
 impl PartialEq for Unit {
-    fn eq(&self, other:&Unit) -> bool {
+    fn eq(&self, other: &Unit) -> bool {
         mem::discriminant(self) == mem::discriminant(other)
     }
 }
-impl Eq for Unit{}
+impl Eq for Unit {}
 impl Hash for Unit {
     fn hash<H: Hasher>(&self, state: &mut H) {
         mem::discriminant(self).hash(state)
@@ -40,20 +40,20 @@ impl Hash for Unit {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum Align{
+pub enum Align {
     Left,
     Middle,
     Right,
 }
 
 #[derive(Clone, Debug)]
-pub enum Property{
+pub enum Property {
     Size(i32), //in pixels
     Family(String),
-    Left(Unit), //in pixels or stretches
-    Width(Unit), //in pixels or stretches
-    Right(Unit), //in pixels or stretches
-    Top(Unit), //in pixels or stretches
+    Left(Unit),   //in pixels or stretches
+    Width(Unit),  //in pixels or stretches
+    Right(Unit),  //in pixels or stretches
+    Top(Unit),    //in pixels or stretches
     Height(Unit), //in pixels or stretches
     Bottom(Unit), //in pixels or stretches
     MinWidth(Unit),
@@ -71,7 +71,7 @@ pub enum Property{
     TextAlign(Align),
 }
 
-lazy_static!{
+lazy_static! {
     pub static ref SIZE: Property = Property::Size(0);
     pub static ref FAMILY: Property = Property::Family(String::from(""));
     pub static ref LEFT: Property = Property::Left(Unit::Stretch(0.0));
@@ -82,61 +82,61 @@ lazy_static!{
     pub static ref BOTTOM: Property = Property::Bottom(Unit::Stretch(0.0));
     pub static ref MIN_WIDTH: Property = Property::MinWidth(Unit::Pixel(0.0));
     pub static ref MIN_HEIGHT: Property = Property::MinHeight(Unit::Pixel(0.0));
-    pub static ref COLOR: Property = Property::Color(ColorF{
+    pub static ref COLOR: Property = Property::Color(ColorF {
         r: 0.2,
         g: 0.2,
         b: 0.2,
         a: 1.0,
     });
-    pub static ref BG_COLOR: Property = Property::BgColor(ColorF{
+    pub static ref BG_COLOR: Property = Property::BgColor(ColorF {
         r: 0.9,
         g: 0.9,
         b: 0.9,
         a: 1.0,
     });
-    pub static ref HOVER_COLOR: Property = Property::HoverColor(ColorF{
+    pub static ref HOVER_COLOR: Property = Property::HoverColor(ColorF {
         r: 0.2,
         g: 0.2,
         b: 0.2,
         a: 1.0,
     });
-    pub static ref HOVER_BG_COLOR: Property = Property::HoverBgColor(ColorF{
+    pub static ref HOVER_BG_COLOR: Property = Property::HoverBgColor(ColorF {
         r: 0.8,
         g: 0.8,
         b: 0.8,
         a: 1.0,
     });
-    pub static ref FOCUS_COLOR: Property = Property::FocusColor(ColorF{
+    pub static ref FOCUS_COLOR: Property = Property::FocusColor(ColorF {
         r: 0.0,
         g: 0.0,
         b: 0.0,
         a: 1.0,
     });
-    pub static ref FOCUS_BG_COLOR: Property = Property::FocusBgColor(ColorF{
+    pub static ref FOCUS_BG_COLOR: Property = Property::FocusBgColor(ColorF {
         r: 0.9,
         g: 0.9,
         b: 0.9,
         a: 1.0,
     });
-    pub static ref ACTIVE_COLOR: Property = Property::ActiveColor(ColorF{
+    pub static ref ACTIVE_COLOR: Property = Property::ActiveColor(ColorF {
         r: 0.2,
         g: 0.2,
         b: 0.2,
         a: 1.0,
     });
-    pub static ref ACTIVE_BG_COLOR: Property = Property::ActiveBgColor(ColorF{
+    pub static ref ACTIVE_BG_COLOR: Property = Property::ActiveBgColor(ColorF {
         r: 1.0,
         g: 1.0,
         b: 1.0,
         a: 1.0,
     });
-    pub static ref DISABLED_COLOR: Property = Property::DisabledColor(ColorF{
+    pub static ref DISABLED_COLOR: Property = Property::DisabledColor(ColorF {
         r: 0.2,
         g: 0.2,
         b: 0.2,
         a: 1.0,
     });
-    pub static ref DISABLED_BG_COLOR: Property = Property::DisabledBgColor(ColorF{
+    pub static ref DISABLED_BG_COLOR: Property = Property::DisabledBgColor(ColorF {
         r: 0.8,
         g: 0.8,
         b: 0.8,
@@ -146,14 +146,14 @@ lazy_static!{
 }
 
 impl PartialEq for Property {
-    fn eq(& self, other:& Property) -> bool {
+    fn eq(&self, other: &Property) -> bool {
         mem::discriminant(self) == mem::discriminant(other)
     }
 }
-impl Eq for Property{}
+impl Eq for Property {}
 
-impl Hash for Property{
-    fn hash<H: Hasher>(&self, state:&mut H){
+impl Hash for Property {
+    fn hash<H: Hasher>(&self, state: &mut H) {
         mem::discriminant(self).hash(state)
     }
 }
@@ -162,11 +162,11 @@ impl Hash for Property{
 pub struct Properties(HashSet<Property>);
 
 impl Properties {
-    pub fn new() -> Properties{
+    pub fn new() -> Properties {
         Properties(HashSet::new())
     }
 
-    pub fn default(& mut self) -> & mut Properties {
+    pub fn default(&mut self) -> &mut Properties {
         self.set(Property::Size(12))
             .set(Property::Family(String::from("Arial")))
             .set(Property::Left(Unit::Stretch(0.0)))
@@ -177,14 +177,14 @@ impl Properties {
             .set(Property::Bottom(Unit::Stretch(0.0)))
             .set(Property::MinWidth(Unit::Pixel(0.0)))
             .set(Property::MinHeight(Unit::Pixel(0.0)))
-            .set(Property::Color(ColorF::new(0.8,0.8,0.8,1.0)))
-            .set(Property::BgColor(ColorF::new(1.0,1.0,1.0,0.0)))
-            .set(Property::FocusColor(ColorF::new(1.0,1.0,1.0,1.0)))
-            .set(Property::FocusBgColor(ColorF::new(0.0,0.0,0.0,0.0)))
-            .set(Property::HoverColor(ColorF::new(0.9,0.9,0.9,1.0)))
-            .set(Property::HoverBgColor(ColorF::new(0.0,0.0,0.0,0.0)))
-            .set(Property::DisabledColor(ColorF::new(0.5,0.5,0.5,1.0)))
-            .set(Property::DisabledBgColor(ColorF::new(0.0,0.0,0.0,0.0)))
+            .set(Property::Color(ColorF::new(0.8, 0.8, 0.8, 1.0)))
+            .set(Property::BgColor(ColorF::new(1.0, 1.0, 1.0, 0.0)))
+            .set(Property::FocusColor(ColorF::new(1.0, 1.0, 1.0, 1.0)))
+            .set(Property::FocusBgColor(ColorF::new(0.0, 0.0, 0.0, 0.0)))
+            .set(Property::HoverColor(ColorF::new(0.9, 0.9, 0.9, 1.0)))
+            .set(Property::HoverBgColor(ColorF::new(0.0, 0.0, 0.0, 0.0)))
+            .set(Property::DisabledColor(ColorF::new(0.5, 0.5, 0.5, 1.0)))
+            .set(Property::DisabledBgColor(ColorF::new(0.0, 0.0, 0.0, 0.0)))
             .set(Property::TextAlign(Align::Left))
     }
 
@@ -196,109 +196,185 @@ impl Properties {
         self
     }
 
-    pub fn get(&self, property: &Property) -> Option<&Property>{
+    pub fn get(&self, property: &Property) -> Option<&Property> {
         self.0.get(property)
     }
 
     pub fn get_size(&self) -> i32 {
-        if let Some(Property::Size(x)) = self.get(&SIZE) {x.clone()} else {panic!("Size not found")}
+        if let Some(Property::Size(x)) = self.get(&SIZE) {
+            x.clone()
+        } else {
+            panic!("Size not found")
+        }
     }
 
     pub fn get_family(&self) -> String {
-        if let Some(Property::Family(x)) = self.get(&FAMILY) {x.clone()} else {panic!("Family not found")}
+        if let Some(Property::Family(x)) = self.get(&FAMILY) {
+            x.clone()
+        } else {
+            panic!("Family not found")
+        }
     }
 
     pub fn get_left(&self) -> Unit {
-        if let Some(Property::Left(x)) = self.get(&LEFT) {x.clone()} else {panic!("Left not found")}
+        if let Some(Property::Left(x)) = self.get(&LEFT) {
+            x.clone()
+        } else {
+            panic!("Left not found")
+        }
     }
 
     pub fn get_width(&self) -> Unit {
-        if let Some(Property::Width(x)) = self.get(&WIDTH) {x.clone()} else {panic!("Width not found")}
+        if let Some(Property::Width(x)) = self.get(&WIDTH) {
+            x.clone()
+        } else {
+            panic!("Width not found")
+        }
     }
 
     pub fn get_right(&self) -> Unit {
-        if let Some(Property::Right(x)) = self.get(&RIGHT) {x.clone()} else {panic!("Right not found")}
+        if let Some(Property::Right(x)) = self.get(&RIGHT) {
+            x.clone()
+        } else {
+            panic!("Right not found")
+        }
     }
 
     pub fn get_top(&self) -> Unit {
-        if let Some(Property::Top(x)) = self.get(&TOP) {x.clone()} else {panic!("Top not found")}
+        if let Some(Property::Top(x)) = self.get(&TOP) {
+            x.clone()
+        } else {
+            panic!("Top not found")
+        }
     }
 
     pub fn get_height(&self) -> Unit {
-        if let Some(Property::Height(x)) = self.get(&HEIGHT) {x.clone()} else {panic!("Height not found")}
+        if let Some(Property::Height(x)) = self.get(&HEIGHT) {
+            x.clone()
+        } else {
+            panic!("Height not found")
+        }
     }
 
     pub fn get_bottom(&self) -> Unit {
-        if let Some(Property::Bottom(x)) = self.get(&BOTTOM) {x.clone()} else {panic!("Bottom not found")}
+        if let Some(Property::Bottom(x)) = self.get(&BOTTOM) {
+            x.clone()
+        } else {
+            panic!("Bottom not found")
+        }
     }
 
     pub fn get_min_width(&self) -> Unit {
-        if let Some(Property::MinWidth(x)) = self.get(&MIN_WIDTH) {x.clone()} else {panic!("Min Width not found")}
+        if let Some(Property::MinWidth(x)) = self.get(&MIN_WIDTH) {
+            x.clone()
+        } else {
+            panic!("Min Width not found")
+        }
     }
 
     pub fn get_min_height(&self) -> Unit {
-        if let Some(Property::MinHeight(x)) = self.get(&MIN_HEIGHT) {x.clone()} else {panic!("Min Height not found")}
+        if let Some(Property::MinHeight(x)) = self.get(&MIN_HEIGHT) {
+            x.clone()
+        } else {
+            panic!("Min Height not found")
+        }
     }
 
     pub fn get_color(&self) -> ColorF {
-        if let Some(Property::Color(x)) = self.get(&COLOR) {x.clone()} else {panic!("Color not found")}
+        if let Some(Property::Color(x)) = self.get(&COLOR) {
+            x.clone()
+        } else {
+            panic!("Color not found")
+        }
     }
 
     pub fn get_bg_color(&self) -> ColorF {
-        if let Some(Property::BgColor(x)) = self.get(&BG_COLOR) {x.clone()} else {panic!("Background Color not found")}
+        if let Some(Property::BgColor(x)) = self.get(&BG_COLOR) {
+            x.clone()
+        } else {
+            panic!("Background Color not found")
+        }
     }
 
     pub fn get_focus_color(&self) -> ColorF {
-        if let Some(Property::FocusColor(x)) = self.get(&FOCUS_COLOR) {x.clone()} else {panic!("Focus Color not found")}
+        if let Some(Property::FocusColor(x)) = self.get(&FOCUS_COLOR) {
+            x.clone()
+        } else {
+            panic!("Focus Color not found")
+        }
     }
 
     pub fn get_focus_bg_color(&self) -> ColorF {
-        if let Some(Property::FocusBgColor(x)) = self.get(&FOCUS_BG_COLOR) {x.clone()} else {panic!("Focus Background Color not found")}
+        if let Some(Property::FocusBgColor(x)) = self.get(&FOCUS_BG_COLOR) {
+            x.clone()
+        } else {
+            panic!("Focus Background Color not found")
+        }
     }
 
     pub fn get_hover_color(&self) -> ColorF {
-        if let Some(Property::HoverColor(x)) = self.get(&HOVER_COLOR) {x.clone()} else {panic!("Hover Color not found")}
+        if let Some(Property::HoverColor(x)) = self.get(&HOVER_COLOR) {
+            x.clone()
+        } else {
+            panic!("Hover Color not found")
+        }
     }
 
     pub fn get_hover_bg_color(&self) -> ColorF {
-        if let Some(Property::HoverBgColor(x)) = self.get(&HOVER_BG_COLOR) {x.clone()} else {panic!("Hover Background Color not found")}
+        if let Some(Property::HoverBgColor(x)) = self.get(&HOVER_BG_COLOR) {
+            x.clone()
+        } else {
+            panic!("Hover Background Color not found")
+        }
     }
 
     pub fn get_disabled_color(&self) -> ColorF {
-        if let Some(Property::DisabledColor(x)) = self.get(&DISABLED_COLOR) {x.clone()} else {panic!("Disabled Color not found")}
+        if let Some(Property::DisabledColor(x)) = self.get(&DISABLED_COLOR) {
+            x.clone()
+        } else {
+            panic!("Disabled Color not found")
+        }
     }
 
     pub fn get_disabled_bg_color(&self) -> ColorF {
-        if let Some(Property::DisabledBgColor(x)) = self.get(&DISABLED_BG_COLOR) {x.clone()} else {panic!("Disabled Background Color not found")}
+        if let Some(Property::DisabledBgColor(x)) = self.get(&DISABLED_BG_COLOR) {
+            x.clone()
+        } else {
+            panic!("Disabled Background Color not found")
+        }
     }
 
     pub fn get_text_align(&self) -> Align {
-        if let Some(Property::TextAlign(x)) = self.get(&TEXT_ALIGN) {x.clone()} else {panic!("Text Align not found")}
+        if let Some(Property::TextAlign(x)) = self.get(&TEXT_ALIGN) {
+            x.clone()
+        } else {
+            panic!("Text Align not found")
+        }
     }
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Position{
+pub struct Position {
     pub x: f32,
     pub y: f32,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub struct Modifiers{
+pub struct Modifiers {
     pub shift: bool,
     pub ctrl: bool,
     pub alt: bool,
-    pub logo: bool
+    pub logo: bool,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum ButtonState{
+pub enum ButtonState {
     Pressed,
     Released,
 }
 
 #[derive(Clone, Debug, PartialEq)]
-pub enum Button{
+pub enum Button {
     Left,
     Middle,
     Right,
@@ -306,22 +382,22 @@ pub enum Button{
 }
 
 #[derive(Clone, Debug)]
-pub struct IdGenerator{
+pub struct IdGenerator {
     pub next_id: Arc<Mutex<u64>>,
 }
 
-impl IdGenerator{
-    pub fn new(start: u64) -> Self{
-        IdGenerator{
+impl IdGenerator {
+    pub fn new(start: u64) -> Self {
+        IdGenerator {
             next_id: Arc::new(Mutex::new(start)),
         }
     }
     pub fn get(&mut self) -> u64 {
         let mut counter = self.next_id.lock().unwrap();
-        *counter +=1;
+        *counter += 1;
         (*counter).clone()
     }
-    pub fn zero(&mut self){
+    pub fn zero(&mut self) {
         let mut counter = self.next_id.lock().unwrap();
         *counter = 0;
     }

--- a/src/gui/properties.rs
+++ b/src/gui/properties.rs
@@ -158,7 +158,7 @@ impl Hash for Property {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct Properties(HashSet<Property>);
 
 impl Properties {
@@ -202,7 +202,7 @@ impl Properties {
 
     pub fn get_size(&self) -> i32 {
         if let Some(Property::Size(x)) = self.get(&SIZE) {
-            x.clone()
+            *x
         } else {
             panic!("Size not found")
         }
@@ -282,7 +282,7 @@ impl Properties {
 
     pub fn get_color(&self) -> ColorF {
         if let Some(Property::Color(x)) = self.get(&COLOR) {
-            x.clone()
+            *x
         } else {
             panic!("Color not found")
         }
@@ -290,7 +290,7 @@ impl Properties {
 
     pub fn get_bg_color(&self) -> ColorF {
         if let Some(Property::BgColor(x)) = self.get(&BG_COLOR) {
-            x.clone()
+            *x
         } else {
             panic!("Background Color not found")
         }
@@ -298,7 +298,7 @@ impl Properties {
 
     pub fn get_focus_color(&self) -> ColorF {
         if let Some(Property::FocusColor(x)) = self.get(&FOCUS_COLOR) {
-            x.clone()
+            *x
         } else {
             panic!("Focus Color not found")
         }
@@ -306,7 +306,7 @@ impl Properties {
 
     pub fn get_focus_bg_color(&self) -> ColorF {
         if let Some(Property::FocusBgColor(x)) = self.get(&FOCUS_BG_COLOR) {
-            x.clone()
+            *x
         } else {
             panic!("Focus Background Color not found")
         }
@@ -314,7 +314,7 @@ impl Properties {
 
     pub fn get_hover_color(&self) -> ColorF {
         if let Some(Property::HoverColor(x)) = self.get(&HOVER_COLOR) {
-            x.clone()
+            *x
         } else {
             panic!("Hover Color not found")
         }
@@ -322,7 +322,7 @@ impl Properties {
 
     pub fn get_hover_bg_color(&self) -> ColorF {
         if let Some(Property::HoverBgColor(x)) = self.get(&HOVER_BG_COLOR) {
-            x.clone()
+            *x
         } else {
             panic!("Hover Background Color not found")
         }
@@ -330,7 +330,7 @@ impl Properties {
 
     pub fn get_disabled_color(&self) -> ColorF {
         if let Some(Property::DisabledColor(x)) = self.get(&DISABLED_COLOR) {
-            x.clone()
+            *x
         } else {
             panic!("Disabled Color not found")
         }
@@ -338,7 +338,7 @@ impl Properties {
 
     pub fn get_disabled_bg_color(&self) -> ColorF {
         if let Some(Property::DisabledBgColor(x)) = self.get(&DISABLED_BG_COLOR) {
-            x.clone()
+            *x
         } else {
             panic!("Disabled Background Color not found")
         }
@@ -395,7 +395,7 @@ impl IdGenerator {
     pub fn get(&mut self) -> u64 {
         let mut counter = self.next_id.lock().unwrap();
         *counter += 1;
-        (*counter).clone()
+        *counter
     }
     pub fn zero(&mut self) {
         let mut counter = self.next_id.lock().unwrap();

--- a/src/gui/window.rs
+++ b/src/gui/window.rs
@@ -1,20 +1,20 @@
+use euclid;
 use gleam::gl;
 use glutin;
 use glutin::GlContext;
 use webrender;
 use webrender::api::*;
-use euclid;
 
-use util::*;
 use elements::{Element, PrimitiveEvent};
 use gui::font;
 use gui::properties;
+use util::*;
 
-use std::sync::{Arc, Mutex};
+use std::mem;
 use std::ops::DerefMut;
+use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::{Duration, SystemTime};
-use std::mem;
 
 impl Into<properties::Position> for glutin::dpi::LogicalPosition {
     fn into(self) -> properties::Position {
@@ -37,10 +37,7 @@ impl Into<properties::Position> for glutin::dpi::PhysicalPosition {
 impl Into<properties::Position> for WorldPoint {
     fn into(self) -> properties::Position {
         match self {
-            WorldPoint { x, y, _unit } => properties::Position {
-                x: x,
-                y: y,
-            }
+            WorldPoint { x, y, _unit } => properties::Position { x: x, y: y },
         }
     }
 }
@@ -59,18 +56,10 @@ impl Into<properties::Modifiers> for glutin::ModifiersState {
 impl Into<properties::Button> for glutin::MouseButton {
     fn into(self) -> properties::Button {
         match self {
-            glutin::MouseButton::Left => {
-                properties::Button::Left
-            }
-            glutin::MouseButton::Right => {
-                properties::Button::Right
-            }
-            glutin::MouseButton::Middle => {
-                properties::Button::Middle
-            }
-            glutin::MouseButton::Other(_) => {
-                properties::Button::Other
-            }
+            glutin::MouseButton::Left => properties::Button::Left,
+            glutin::MouseButton::Right => properties::Button::Right,
+            glutin::MouseButton::Middle => properties::Button::Middle,
+            glutin::MouseButton::Other(_) => properties::Button::Other,
         }
     }
 }
@@ -78,12 +67,8 @@ impl Into<properties::Button> for glutin::MouseButton {
 impl Into<properties::ButtonState> for glutin::ElementState {
     fn into(self) -> properties::ButtonState {
         match self {
-            glutin::ElementState::Pressed => {
-                properties::ButtonState::Pressed
-            }
-            glutin::ElementState::Released => {
-                properties::ButtonState::Released
-            }
+            glutin::ElementState::Pressed => properties::ButtonState::Pressed,
+            glutin::ElementState::Released => properties::ButtonState::Released,
         }
     }
 }
@@ -110,11 +95,13 @@ impl RenderNotifier for WindowNotifier {
         let _ = self.events_proxy.wakeup();
     }
 
-    fn new_frame_ready(&self,
-                       _doc_id: DocumentId,
-                       _scrolled: bool,
-                       _composite_needed: bool,
-                       _render_time: Option<u64>) {
+    fn new_frame_ready(
+        &self,
+        _doc_id: DocumentId,
+        _scrolled: bool,
+        _composite_needed: bool,
+        _render_time: Option<u64>,
+    ) {
         self.wake_up();
     }
 }
@@ -136,8 +123,8 @@ struct Internals {
 impl Internals {
     fn new(name: String, width: f64, height: f64) -> Internals {
         let events_loop = glutin::EventsLoop::new();
-        let context_builder = glutin::ContextBuilder::new()
-            .with_gl(glutin::GlRequest::GlThenGles {
+        let context_builder =
+            glutin::ContextBuilder::new().with_gl(glutin::GlRequest::GlThenGles {
                 opengl_version: (3, 2),
                 opengles_version: (3, 0),
             });
@@ -145,8 +132,7 @@ impl Internals {
             .with_title(name.clone())
             .with_multitouch()
             .with_dimensions(glutin::dpi::LogicalSize::new(width, height));
-        let window = glutin::GlWindow::new(window_builder, context_builder, &events_loop)
-            .unwrap();
+        let window = glutin::GlWindow::new(window_builder, context_builder, &events_loop).unwrap();
 
         unsafe {
             window.make_current().ok();
@@ -166,29 +152,30 @@ impl Internals {
 
         let opts = webrender::RendererOptions {
             device_pixel_ratio: dpi as f32,
-            clear_color: Some(ColorF::new(0.2,0.2,0.2, 1.0)),
+            clear_color: Some(ColorF::new(0.2, 0.2, 0.2, 1.0)),
             //enable_scrollbars: true,
             //enable_aa:true,
             ..webrender::RendererOptions::default()
         };
 
         let framebuffer_size = {
-            let size = window
-                .get_inner_size()
-                .unwrap()
-                .to_physical(dpi);
+            let size = window.get_inner_size().unwrap().to_physical(dpi);
             DeviceUintSize::new(size.width as u32, size.height as u32)
         };
 
         let notifier = Box::new(WindowNotifier::new(events_loop.create_proxy()));
-        let (renderer, sender) = webrender::Renderer::new(gl.clone(), notifier, opts, None).unwrap();
+        let (renderer, sender) =
+            webrender::Renderer::new(gl.clone(), notifier, opts, None).unwrap();
         let api = sender.create_api();
         let document_id = api.add_document(framebuffer_size, 0);
 
         let epoch = Epoch(0);
         let pipeline_id = PipelineId(0, 0);
 
-        let font_store = Arc::new(Mutex::new(font::FontStore::new(api.clone_sender().create_api(), document_id.clone())));
+        let font_store = Arc::new(Mutex::new(font::FontStore::new(
+            api.clone_sender().create_api(),
+            document_id.clone(),
+        )));
 
         let mut txn = Transaction::new();
         txn.set_root_pipeline(pipeline_id);
@@ -219,64 +206,97 @@ impl Internals {
 
         self.events_loop.poll_events(|event| {
             match event {
-                glutin::Event::WindowEvent { event: glutin::WindowEvent::CloseRequested, window_id } => {
-                    { TODEL.lock().unwrap().push(window_id); }
+                glutin::Event::WindowEvent {
+                    event: glutin::WindowEvent::CloseRequested,
+                    window_id,
+                } => {
+                    {
+                        TODEL.lock().unwrap().push(window_id);
+                    }
                     events.push(PrimitiveEvent::Exit);
                 }
-                glutin::Event::WindowEvent { event: glutin::WindowEvent::CursorEntered { .. }, .. } => {
+                glutin::Event::WindowEvent {
+                    event: glutin::WindowEvent::CursorEntered { .. },
+                    ..
+                } => {
                     //events.push(PrimitiveEvent::CursorEntered);
                     cursor_in_window = true;
                 }
-                glutin::Event::WindowEvent { event: glutin::WindowEvent::CursorMoved { position, .. }, .. } => {
+                glutin::Event::WindowEvent {
+                    event: glutin::WindowEvent::CursorMoved { position, .. },
+                    ..
+                } => {
                     if cursor_in_window {
                         cursor_position = WorldPoint::new(position.x as f32, position.y as f32);
                         events.push(PrimitiveEvent::CursorMoved(position.into()));
                     }
                 }
-                glutin::Event::WindowEvent { event: glutin::WindowEvent::CursorLeft { .. }, .. } => {
+                glutin::Event::WindowEvent {
+                    event: glutin::WindowEvent::CursorLeft { .. },
+                    ..
+                } => {
                     //events.push(PrimitiveEvent::CursorLeft);
                     cursor_in_window = false;
                     cursor_position.x = -1.0;
                     cursor_position.y = -1.0;
                 }
-                glutin::Event::WindowEvent { event: glutin::WindowEvent::Resized(size), .. } => {
+                glutin::Event::WindowEvent {
+                    event: glutin::WindowEvent::Resized(size),
+                    ..
+                } => {
                     events.push(PrimitiveEvent::Resized(size));
                 }
-                glutin::Event::WindowEvent { event: glutin::WindowEvent::HiDpiFactorChanged(factor), .. } => {
+                glutin::Event::WindowEvent {
+                    event: glutin::WindowEvent::HiDpiFactorChanged(factor),
+                    ..
+                } => {
                     dpi = factor;
                     events.push(PrimitiveEvent::DPI(factor));
                 }
-                glutin::Event::WindowEvent { event: glutin::WindowEvent::MouseInput { state, button, modifiers, .. }, .. } => {
+                glutin::Event::WindowEvent {
+                    event:
+                        glutin::WindowEvent::MouseInput {
+                            state,
+                            button,
+                            modifiers,
+                            ..
+                        },
+                    ..
+                } => {
                     let _pos: properties::Position = cursor_position.clone().into();
                     let _button = button.into();
                     let _state = state.into();
                     let _modifiers = modifiers.into();
 
                     if tags.len() > 0 {
-                        if button == glutin::MouseButton::Left && state == glutin::ElementState::Released {
+                        if button == glutin::MouseButton::Left
+                            && state == glutin::ElementState::Released
+                        {
                             events.push(PrimitiveEvent::SetFocus(true));
                         }
                     }
                     events.push(PrimitiveEvent::Button(_pos, _button, _state, _modifiers));
                 }
-                glutin::Event::WindowEvent { event: glutin::WindowEvent::MouseWheel { delta, modifiers, .. }, .. } => {
+                glutin::Event::WindowEvent {
+                    event:
+                        glutin::WindowEvent::MouseWheel {
+                            delta, modifiers, ..
+                        },
+                    ..
+                } => {
                     if txn.is_none() {
                         txn = Some(Transaction::new());
                     }
                     const LINE_HEIGHT: f32 = 38.0;
                     let (dx, dy) = match modifiers.alt {
-                        true => {
-                            match delta {
-                                glutin::MouseScrollDelta::LineDelta(_, dy) => (dy * LINE_HEIGHT, 0.0),
-                                glutin::MouseScrollDelta::PixelDelta(pos) => (pos.y as f32, 0.0),
-                            }
-                        }
-                        _ => {
-                            match delta {
-                                glutin::MouseScrollDelta::LineDelta(_, dy) => (0.0, dy * LINE_HEIGHT),
-                                glutin::MouseScrollDelta::PixelDelta(pos) => (0.0, pos.y as f32),
-                            }
-                        }
+                        true => match delta {
+                            glutin::MouseScrollDelta::LineDelta(_, dy) => (dy * LINE_HEIGHT, 0.0),
+                            glutin::MouseScrollDelta::PixelDelta(pos) => (pos.y as f32, 0.0),
+                        },
+                        _ => match delta {
+                            glutin::MouseScrollDelta::LineDelta(_, dy) => (0.0, dy * LINE_HEIGHT),
+                            glutin::MouseScrollDelta::PixelDelta(pos) => (0.0, pos.y as f32),
+                        },
                     };
 
                     if let Some(ref mut _txn) = txn {
@@ -288,17 +308,38 @@ impl Internals {
 
                     //println!("scrolling {} {}",dx,dy);
                 }
-                glutin::Event::WindowEvent { event: glutin::WindowEvent::KeyboardInput { input: glutin::KeyboardInput { scancode, state, virtual_keycode, modifiers }, .. }, .. } => {
-                    events.push(PrimitiveEvent::KeyInput(virtual_keycode, scancode, state.into(), modifiers.into()));
+                glutin::Event::WindowEvent {
+                    event:
+                        glutin::WindowEvent::KeyboardInput {
+                            input:
+                                glutin::KeyboardInput {
+                                    scancode,
+                                    state,
+                                    virtual_keycode,
+                                    modifiers,
+                                },
+                            ..
+                        },
+                    ..
+                } => {
+                    events.push(PrimitiveEvent::KeyInput(
+                        virtual_keycode,
+                        scancode,
+                        state.into(),
+                        modifiers.into(),
+                    ));
                 }
-                glutin::Event::WindowEvent { event: glutin::WindowEvent::ReceivedCharacter(c), .. } => {
+                glutin::Event::WindowEvent {
+                    event: glutin::WindowEvent::ReceivedCharacter(c),
+                    ..
+                } => {
                     if c == '\x1b' {
                         events.push(PrimitiveEvent::SetFocus(false));
                     } else {
                         events.push(PrimitiveEvent::Char(c));
                     }
                 }
-                _ => ()
+                _ => (),
             }
         });
 
@@ -386,18 +427,14 @@ impl Window {
             new_tags = tags.clone();
         } else {
             for t in tags.iter() {
-                let exists = self.tags.iter().find(|x| {
-                    *x == t
-                });
+                let exists = self.tags.iter().find(|x| *x == t);
                 if exists.is_none() {
                     new_tags.push(t.clone());
                 }
             }
 
             for t in self.tags.iter() {
-                let exists = tags.iter().find(|x| {
-                    *x == t
-                });
+                let exists = tags.iter().find(|x| *x == t);
                 if exists.is_none() {
                     old_tags.push(t.clone());
                 }
@@ -413,7 +450,6 @@ impl Window {
         (new_tags, old_tags)
     }
 
-
     pub fn tick(&mut self) -> bool {
         let (new_tags, old_tags) = self.get_tags();
         let tags = self.tags.clone();
@@ -428,17 +464,23 @@ impl Window {
                 dpi = i.dpi;
                 api = i.api.clone_sender().create_api();
             }
-            _ => panic!("in tick but no window internals initialized")
+            _ => panic!("in tick but no window internals initialized"),
         }
 
         if new_tags.len() > 0 {
             //events.insert(0,PrimitiveEvent::HoverBegin(new_tags));
-            self.root.lock().unwrap().on_primitive_event(&[], PrimitiveEvent::HoverBegin(new_tags));
+            self.root
+                .lock()
+                .unwrap()
+                .on_primitive_event(&[], PrimitiveEvent::HoverBegin(new_tags));
         }
 
         if old_tags.len() > 0 {
             //events.insert( 0,PrimitiveEvent::HoverEnd(old_tags));
-            self.root.lock().unwrap().on_primitive_event(&[], PrimitiveEvent::HoverEnd(old_tags));
+            self.root
+                .lock()
+                .unwrap()
+                .on_primitive_event(&[], PrimitiveEvent::HoverEnd(old_tags));
         }
 
         //only for debug. take out later?
@@ -467,25 +509,39 @@ impl Window {
                     if !*b {
                         self.root.lock().unwrap().on_primitive_event(&[], e.clone());
                     } else {
-                        self.root.lock().unwrap().on_primitive_event(&tags, e.clone());
+                        self.root
+                            .lock()
+                            .unwrap()
+                            .on_primitive_event(&tags, e.clone());
                     }
                 }
                 PrimitiveEvent::Button(_, _, _, _) => {
-                    self.root.lock().unwrap().on_primitive_event(&tags, e.clone());
+                    self.root
+                        .lock()
+                        .unwrap()
+                        .on_primitive_event(&tags, e.clone());
                 }
                 PrimitiveEvent::Char(_) => {
-                    self.root.lock().unwrap().on_primitive_event(&tags, e.clone());
+                    self.root
+                        .lock()
+                        .unwrap()
+                        .on_primitive_event(&tags, e.clone());
                 }
                 PrimitiveEvent::CursorMoved(_) => {
-                    self.root.lock().unwrap().on_primitive_event(&tags, e.clone());
+                    self.root
+                        .lock()
+                        .unwrap()
+                        .on_primitive_event(&tags, e.clone());
                 }
                 PrimitiveEvent::KeyInput(_, _, _, _) => {
-                    self.root.lock().unwrap().on_primitive_event(&tags, e.clone());
+                    self.root
+                        .lock()
+                        .unwrap()
+                        .on_primitive_event(&tags, e.clone());
                 }
-                _ => ()
+                _ => (),
             }
         }
-
 
         let mut txn = Transaction::new();
         let mut builder = None;
@@ -498,10 +554,7 @@ impl Window {
 
             dpi = i.gl_window.get_hidpi_factor();
             let framebuffer_size = {
-                let size = i.gl_window
-                    .get_inner_size()
-                    .unwrap()
-                    .to_physical(dpi);
+                let size = i.gl_window.get_inner_size().unwrap().to_physical(dpi);
                 DeviceUintSize::new(size.width as u32, size.height as u32)
             };
             let layout_size = framebuffer_size.to_f32() / euclid::TypedScale::new(dpi as f32);
@@ -531,13 +584,7 @@ impl Window {
                 dpi as f32,
             );
 
-            txn.set_display_list(
-                i.epoch,
-                None,
-                layout_size,
-                builder.finalize(),
-                true,
-            );
+            txn.set_display_list(i.epoch, None, layout_size, builder.finalize(), true);
             //txn.set_root_pipeline(i.pipeline_id);
             txn.generate_frame();
             i.api.send_transaction(i.document_id, txn);
@@ -551,13 +598,17 @@ impl Window {
         exit
     }
 
-    fn render_root(&mut self, api: &RenderApi, builder: &mut DisplayListBuilder, font_store: &mut font::FontStore, dpi: f32) {
+    fn render_root(
+        &mut self,
+        api: &RenderApi,
+        builder: &mut DisplayListBuilder,
+        font_store: &mut font::FontStore,
+        dpi: f32,
+    ) {
         let mut gen = self.id_generator.clone();
         gen.zero();
 
-        let info = LayoutPrimitiveInfo::new(
-            (0.0, 0.0).by(self.width as f32, self.height as f32)
-        );
+        let info = LayoutPrimitiveInfo::new((0.0, 0.0).by(self.width as f32, self.height as f32));
         builder.push_stacking_context(
             &info,
             None,
@@ -567,13 +618,20 @@ impl Window {
             RasterSpace::Screen,
         );
 
-        self.root.lock().unwrap().render(api, builder, properties::Extent {
-            x: 0.0,
-            y: 0.0,
-            w: self.width as f32,
-            h: self.height as f32,
-            dpi,
-        }, font_store, None, &mut gen);
+        self.root.lock().unwrap().render(
+            api,
+            builder,
+            properties::Extent {
+                x: 0.0,
+                y: 0.0,
+                w: self.width as f32,
+                h: self.height as f32,
+                dpi,
+            },
+            font_store,
+            None,
+            &mut gen,
+        );
 
         builder.pop_stacking_context();
     }
@@ -588,13 +646,13 @@ impl Drop for Window {
     }
 }
 
-lazy_static!(
-    static ref TOADD: Mutex<Vec<(Arc<Mutex<Element>>,String,f64,f64)>> = Mutex::new(vec![]);
+lazy_static! {
+    static ref TOADD: Mutex<Vec<(Arc<Mutex<Element>>, String, f64, f64)>> = Mutex::new(vec![]);
     static ref TODEL: Mutex<Vec<glutin::WindowId>> = Mutex::new(vec![]);
-);
+}
 
 pub struct Manager {
-    windows: Vec<Window>
+    windows: Vec<Window>,
 }
 
 impl Manager {
@@ -603,9 +661,7 @@ impl Manager {
 
         unsafe {
             if MANAGER.is_none() {
-                MANAGER = Some(Arc::new(Mutex::new(Manager {
-                    windows: vec![]
-                })));
+                MANAGER = Some(Arc::new(Mutex::new(Manager { windows: vec![] })));
             }
 
             MANAGER.clone()
@@ -642,10 +698,10 @@ impl Manager {
                     //render the windows
                     while i < wm.windows.len() {
                         //if
-                        wm.windows[i].tick();// {
-                        //    let w = wm.windows.remove(i);
-                        //    w.deinit();
-                        //} else {
+                        wm.windows[i].tick(); // {
+                                              //    let w = wm.windows.remove(i);
+                                              //    w.deinit();
+                                              //} else {
                         i += 1;
                         //}
                     }
@@ -675,13 +731,13 @@ impl Manager {
                     }
                 }
             }
-            if let Ok(_t) = lasttime.elapsed(){
+            if let Ok(_t) = lasttime.elapsed() {
                 let mut _t = _t.subsec_millis() as u64;
                 if _t > fps {
                     _t = fps;
                 }
                 thread::sleep(Duration::from_millis(fps - _t));
-            }else {
+            } else {
                 thread::sleep(Duration::from_millis(fps));
             }
         }

--- a/src/gui/window.rs
+++ b/src/gui/window.rs
@@ -418,7 +418,7 @@ impl Window {
         let (new_tags, old_tags) = self.get_tags();
         let tags = self.tags.clone();
 
-        let mut events;
+        let events;
         let mut dpi;
         let api;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,20 +1,20 @@
-
 #![windows_subsystem = "windows"]
-extern crate winit;
-extern crate glutin;
-pub extern crate webrender;
-extern crate gleam;
 extern crate app_units;
 extern crate euclid;
+extern crate gleam;
+extern crate glutin;
+pub extern crate webrender;
+extern crate winit;
 //extern crate rusttype;
 //extern crate font_loader as floader;
 extern crate clipboard;
 extern crate font_kit;
 //#[macro_use] extern crate scan_rules;
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate lazy_static;
 
 pub mod data;
-mod util;
 pub mod elements;
 pub mod gui;
+mod util;
 //pub use self::webrender;

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,7 @@ pub trait HandyDandyRectBuilder<T> {
 }
 // Allows doing `(x, y).to(x2, y2)` or `(x, y).by(width, height)` with i32
 // values to build a f32 LayoutRect
-impl HandyDandyRectBuilder <i32> for (i32, i32) {
+impl HandyDandyRectBuilder<i32> for (i32, i32) {
     fn to(&self, x2: i32, y2: i32) -> LayoutRect {
         LayoutRect::new(
             LayoutPoint::new(self.0 as f32, self.1 as f32),
@@ -22,7 +22,7 @@ impl HandyDandyRectBuilder <i32> for (i32, i32) {
     }
 }
 
-impl HandyDandyRectBuilder <f32> for (f32, f32) {
+impl HandyDandyRectBuilder<f32> for (f32, f32) {
     fn to(&self, x2: f32, y2: f32) -> LayoutRect {
         LayoutRect::new(
             LayoutPoint::new(self.0, self.1),
@@ -31,9 +31,6 @@ impl HandyDandyRectBuilder <f32> for (f32, f32) {
     }
 
     fn by(&self, w: f32, h: f32) -> LayoutRect {
-        LayoutRect::new(
-            LayoutPoint::new(self.0, self.1),
-            LayoutSize::new(w, h),
-        )
+        LayoutRect::new(LayoutPoint::new(self.0, self.1), LayoutSize::new(w, h))
     }
 }


### PR DESCRIPTION
- Fixed warnings. E.g. [`cargo fix`](https://github.com/rust-lang-nursery/rustfix)
- Cleanup with `cargo fmt`
- Remove lint with [`cargo clippy`](https://github.com/rust-lang-nursery/rust-clippy)
- Additional note: Using a leading underscore on variable names is bad practice when the variable is actually used. See [FontRaster impl](https://github.com/fasihrana/skryn/blob/4be16c57256a951a9d83a758e9b07f3db0cb7779/src/gui/font.rs#L214-L242) for examples.
- The `HoverBegin` and `HoverEnd` primitive events were unhandled due to match evaluation order. Handling these events causes a panic in the `WRRenderBackend` thread. I left a comment for this, and commented the code, retaining the previous behavior.